### PR TITLE
Example of options classes, or generic templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.cloud</groupId>
@@ -136,6 +136,21 @@
       <version>1.7.4</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>7.0.1.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>jakarta.el</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
+      <artifactId>hibernate-validator-cdi</artifactId>
+      <version>7.0.1.Final</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -165,7 +180,8 @@
             </goals>
             <configuration>
               <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                <transformer
+                    implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                 </transformer>
               </transformers>
               <filters>

--- a/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
@@ -24,6 +24,7 @@ public interface BaseTemplate {
   /** List of all templates. */
   enum TemplateName {
     WORDCOUNT("WORDCOUNT"),
+    GENERIC("GENERIC"),
     HIVETOGCS("HIVETOGCS"),
     PUBSUBTOBQ("PUBSUBTOBQ"),
     SPANNERTOGCS("SPANNERTOGCS"),

--- a/src/main/java/com/google/cloud/dataproc/templates/GenericTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/GenericTemplate.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates;
+
+import com.google.cloud.dataproc.templates.options.TemplateOptionsFactory;
+import com.google.cloud.dataproc.templates.util.PropertyUtil;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Properties;
+import org.apache.spark.sql.DataFrameReader;
+import org.apache.spark.sql.DataFrameWriter;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GenericTemplate implements BaseTemplate {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GenericTemplate.class);
+
+  public void runTemplate() {
+    Properties properties = PropertyUtil.getProperties();
+    String inputFormat = properties.getProperty("input.format");
+    String outputFormat = properties.getProperty("output.format");
+    Map<?, ?> inputOptions =
+        TemplateOptionsFactory.unscopeProperties(
+            properties, String.format("input.%s.", inputFormat));
+    Map<?, ?> outputOptions =
+        TemplateOptionsFactory.unscopeProperties(
+            properties, String.format("output.%s.", outputFormat));
+
+    SparkSession spark = SparkSession.builder().appName("Generic Template").getOrCreate();
+
+    String inputPath =
+        Optional.ofNullable(inputOptions.remove("path")).map(Object::toString).orElse(null);
+    String outputPath =
+        Optional.ofNullable(outputOptions.remove("path")).map(Object::toString).orElse(null);
+
+    LOGGER.info("Input Format: {}", inputFormat);
+    LOGGER.info("Input Path: {}", inputPath);
+    LOGGER.info("Input Options: {}", inputOptions);
+    LOGGER.info("Output Format: {}", outputFormat);
+    LOGGER.info("Output Path: {}", outputPath);
+    LOGGER.info("Output Options: {}", outputOptions);
+
+    DataFrameReader reader = spark.read().format(inputFormat);
+    for (Entry<?, ?> entry : inputOptions.entrySet()) {
+      reader = reader.option(entry.getKey().toString(), entry.getValue().toString());
+    }
+    Dataset<Row> dataset = inputPath != null ? reader.load(inputPath) : reader.load();
+
+    DataFrameWriter<?> writer = dataset.write().format(outputFormat);
+    for (Entry<?, ?> entry : inputOptions.entrySet()) {
+      reader = reader.option(entry.getKey().toString(), entry.getValue().toString());
+    }
+
+    if (inputPath != null) {
+      writer.save(outputPath);
+    } else {
+      writer.save();
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
@@ -16,6 +16,7 @@
 package com.google.cloud.dataproc.templates.main;
 
 import com.google.cloud.dataproc.templates.BaseTemplate.TemplateName;
+import com.google.cloud.dataproc.templates.GenericTemplate;
 import com.google.cloud.dataproc.templates.databases.SpannerToGCS;
 import com.google.cloud.dataproc.templates.gcs.GCStoBigquery;
 import com.google.cloud.dataproc.templates.hive.HiveToBigQuery;
@@ -59,6 +60,11 @@ public class DataProcTemplate {
       case WORDCOUNT:
         {
           new WordCount().runTemplate();
+        }
+        break;
+      case GENERIC:
+        {
+          new GenericTemplate().runTemplate();
         }
         break;
       case HIVETOGCS:

--- a/src/main/java/com/google/cloud/dataproc/templates/options/BaseOptions.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/BaseOptions.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+public interface BaseOptions {
+  String getOptionsPrefix();
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/BigQueryOutputOptions.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/BigQueryOutputOptions.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public class BigQueryOutputOptions implements BaseOptions {
+
+  @NotEmpty private String table;
+  @NotEmpty private String temporaryGcsBucket;
+
+  public String getTable() {
+    return table;
+  }
+
+  public void setTable(String table) {
+    this.table = table;
+  }
+
+  public String getTemporaryGcsBucket() {
+    return temporaryGcsBucket;
+  }
+
+  public void setTemporaryGcsBucket(String temporaryGcsBucket) {
+    this.temporaryGcsBucket = temporaryGcsBucket;
+  }
+
+  @Override
+  public String getOptionsPrefix() {
+    return "bigquery.";
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/GCSInputOptions.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/GCSInputOptions.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public class GCSInputOptions implements BaseOptions {
+
+  public enum Format {
+    AVRO,
+    PARQUET,
+    JSON,
+    CSV;
+  }
+
+  @NotEmpty private String path;
+
+  @NotNull
+  @Pattern(regexp = "AVRO|PARQUET|JSON|CSV")
+  private String format;
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public void setFormat(String format) {
+    this.format = format;
+  }
+
+  public Format getFormatEnum() {
+    return Format.valueOf(getFormat());
+  }
+
+  @Override
+  public String getOptionsPrefix() {
+    return "gcs.";
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/GCSOutputOptions.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/GCSOutputOptions.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import org.codehaus.jackson.map.Serializers.Base;
+
+public class GCSOutputOptions implements BaseOptions {
+  @NotEmpty public String path;
+
+  @NotNull
+  @Pattern(regexp = "AVRO|PARQUET|JSON|CSV")
+  public String format;
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
+  }
+
+  public String getFormat() {
+    return format;
+  }
+
+  public void setFormat(String format) {
+    this.format = format;
+  }
+
+  @Override
+  public String getOptionsPrefix() {
+    return "gcs";
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptions.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptions.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public class TemplateOptions implements BaseOptions {
+
+  @NotEmpty private String projectId;
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public void setProjectId(String projectId) {
+    this.projectId = projectId;
+  }
+
+  @Override
+  public String getOptionsPrefix() {
+    return null;
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptionsFactory.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptionsFactory.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import com.google.common.base.Strings;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.commons.beanutils.BeanUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TemplateOptionsFactory<T extends BaseOptions> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TemplateOptionsFactory.class);
+
+  private final Map<?, ?> properties;
+  private final Class<T> optionsClazz;
+
+  public TemplateOptionsFactory(Map<?, ?> properties, Class<T> optionsClazz) {
+    this.properties = properties;
+    this.optionsClazz = optionsClazz;
+  }
+
+  public static TemplateOptionsFactory<TemplateOptions> fromProps(Properties properties) {
+    return new TemplateOptionsFactory<>(properties, TemplateOptions.class);
+  }
+
+  public <Opts extends BaseOptions> TemplateOptionsFactory<Opts> as(Class<Opts> optionsClazz) {
+    return new TemplateOptionsFactory<>(this.properties, optionsClazz);
+  }
+
+  Map<?, ?> unscopeProperties(Map<?, ?> properties, String prefix) {
+    if (Strings.isNullOrEmpty(prefix)) {
+      return properties;
+    }
+    // remove the qualifier prefix
+    Properties props = new Properties();
+    for (Entry<?, ?> entry : properties.entrySet()) {
+      String key = entry.getKey().toString();
+      if (key.startsWith(prefix)) {
+        props.put(key.substring(prefix.length()), entry.getValue());
+      }
+    }
+    if (props.isEmpty()) {
+      LOGGER.warn("No matching properties remaining after stripping options prefix \"{}\"", prefix);
+    }
+    return props;
+  }
+
+  public T create() {
+    T optionsBean;
+    try {
+      optionsBean = optionsClazz.getConstructor().newInstance();
+    } catch (InstantiationException
+        | IllegalAccessException
+        | InvocationTargetException
+        | NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Could not construct options bean %s", optionsClazz), e);
+    }
+    LOGGER.info(
+        "Creating options bean {} from properties {} with scope {}",
+        optionsClazz,
+        properties,
+        optionsBean);
+    Map<?, ?> props = unscopeProperties(properties, optionsBean.getOptionsPrefix());
+    try {
+      BeanUtils.populate(optionsBean, props);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      throw new IllegalArgumentException(
+          String.format("Could not populate properties to options bean %s", optionsClazz), e);
+    }
+    return validate(optionsBean);
+  }
+
+  public T validate(T optionsBean) {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    Validator validator = factory.getValidator();
+    Set<ConstraintViolation<T>> violations = validator.validate(optionsBean);
+    for (ConstraintViolation<T> violation : violations) {
+      LOGGER.error("Option violation for: {}; {}; in {}", violation.getPropertyPath(), violation.getMessage(), violation.getRootBeanClass());
+    }
+    if (!violations.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format("Options could not be validated, %s", violations));
+    }
+    return optionsBean;
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptionsFactory.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/options/TemplateOptionsFactory.java
@@ -33,10 +33,10 @@ public class TemplateOptionsFactory<T extends BaseOptions> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TemplateOptionsFactory.class);
 
-  private final Map<?, ?> properties;
+  private final Properties properties;
   private final Class<T> optionsClazz;
 
-  public TemplateOptionsFactory(Map<?, ?> properties, Class<T> optionsClazz) {
+  public TemplateOptionsFactory(Properties properties, Class<T> optionsClazz) {
     this.properties = properties;
     this.optionsClazz = optionsClazz;
   }
@@ -49,7 +49,7 @@ public class TemplateOptionsFactory<T extends BaseOptions> {
     return new TemplateOptionsFactory<>(this.properties, optionsClazz);
   }
 
-  Map<?, ?> unscopeProperties(Map<?, ?> properties, String prefix) {
+  public static Properties unscopeProperties(Properties properties, String prefix) {
     if (Strings.isNullOrEmpty(prefix)) {
       return properties;
     }
@@ -98,7 +98,11 @@ public class TemplateOptionsFactory<T extends BaseOptions> {
     Validator validator = factory.getValidator();
     Set<ConstraintViolation<T>> violations = validator.validate(optionsBean);
     for (ConstraintViolation<T> violation : violations) {
-      LOGGER.error("Option violation for: {}; {}; in {}", violation.getPropertyPath(), violation.getMessage(), violation.getRootBeanClass());
+      LOGGER.error(
+          "Option violation for: {}; {}; in {}",
+          violation.getPropertyPath(),
+          violation.getMessage(),
+          violation.getRootBeanClass());
     }
     if (!violations.isEmpty()) {
       throw new IllegalArgumentException(

--- a/src/main/resources/template.properties
+++ b/src/main/resources/template.properties
@@ -91,3 +91,10 @@ s3.bq.input.location=<s3-input-location>
 s3.bq.output.dataset.name=<bq-dataset-name>
 s3.bq.output.table.name=<bq-output-table>
 s3.bq.ld.temp.bucket.name=<temp-bucket>
+
+# Example using option classes
+projectId=asdf
+gcs.path=asdf
+gcs.format=asdf
+bigquery.table=asdf
+bigquery.temporaryGcsBucket=asdf

--- a/src/test/java/com/google/cloud/dataproc/templates/options/BigQueryOutputOptionsTest.java
+++ b/src/test/java/com/google/cloud/dataproc/templates/options/BigQueryOutputOptionsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BigQueryOutputOptionsTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BigQueryOutputOptionsTest.class);
+  private Validator validator;
+
+  @BeforeEach
+  void setup() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  void testFoobar() throws InvocationTargetException, IllegalAccessException {
+    Properties props = new Properties();
+    props.put("bigquery.table", "table name");
+    props.put("bigquery.temporaryGcsBucket", "bucket");
+
+    BigQueryOutputOptions options = TemplateOptionsFactory.fromProps(props)
+        .as(BigQueryOutputOptions.class).create();
+    assertEquals("bigquery.", options.getOptionsPrefix());
+    assertEquals("bucket", options.getTemporaryGcsBucket());
+    assertEquals("table name", options.getTable());
+
+  }
+
+}

--- a/src/test/java/com/google/cloud/dataproc/templates/options/GCSInputOptionsTest.java
+++ b/src/test/java/com/google/cloud/dataproc/templates/options/GCSInputOptionsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.options;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.cloud.dataproc.templates.options.GCSInputOptions.Format;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class GCSInputOptionsTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GCSInputOptionsTest.class);
+  private Validator validator;
+
+  @BeforeEach
+  void setup() {
+    ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @Test
+  void testFoobar() {
+    Properties props = new Properties();
+    props.put("gcs.format", "AVRO");
+    props.put("gcs.path", "gs://path...");
+
+    GCSInputOptions options = TemplateOptionsFactory.fromProps(props)
+        .as(GCSInputOptions.class).create();
+    assertEquals("gcs.", options.getOptionsPrefix());
+    assertEquals("gs://path...", options.getPath());
+    assertEquals("AVRO", options.getFormat());
+    assertEquals(Format.AVRO, options.getFormatEnum());
+  }
+
+}


### PR DESCRIPTION
This is not yet for merging, just to spark a discussion on how we might improve our options/properties handling.

This approach uses the apache BeanUtils and the standard java validation framework for validating options pojos, this greatly reduces the amount of setup code.
eg: this duplicated per property:
```
prop = getProperties().getProperty(PROP);
if (StringUtils.isAllBlank(prop)) {
LOGGER.error("{} is required parameter. ", PROP);
throw new IllegalArgumentException(...)
}
LOGGER.info(PROP, prop);
etc..
```

Becomes this:
```
GCSInputOptions inputOptions = optionsFactory.as(GCSInputOptions.class).create();
```

This is only for options that have values passed into the template, other TemplateConstants still need to be kept somewhere (eg, the GCS "header", "inferSchema", "com.databricks.spark.avro" constants).

