### PR TITLE
Update log4j to 2.17 to address CVE-2021-45105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Log4j version update because of CVE-2021-45105 vulnerability.

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105