### PR TITLE
Pubsub to Gcs template review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.ipr
 *.iws
 .idea
+.DS_Store
 
 # Eclipse
 build/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Please refer to the [Dataproc Templates (Java - Spark) README](java/README.md)  
 * [S3ToBigQuery](java/src/main/java/com/google/cloud/dataproc/templates/s3/README.md)
 * [JDBCToBigQuery](java/src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
 * [JDBCToGCS](java/src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
+* [PubSubToGCS](java/src/main/java/com/google/cloud/dataproc/templates/pubsub/README.md#2-pubsub-to-gcs)
 * [WordCount](java/src/main/java/com/google/cloud/dataproc/templates/word/WordCount.java)
 * [GeneralTemplate](java/src/main/java/com/google/cloud/dataproc/templates/general/README.md)
 

--- a/java/README.md
+++ b/java/README.md
@@ -11,6 +11,7 @@
 * [S3ToBigQuery](src/main/java/com/google/cloud/dataproc/templates/s3/README.md)
 * [JDBCToBigQuery](src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
 * [JDBCToGCS](src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
+* [PubSubToGCS](src/main/java/com/google/cloud/dataproc/templates/pubsub/README.md#2-pubsub-to-gcs)
 * [WordCount](src/main/java/com/google/cloud/dataproc/templates/word/WordCount.java)
 * [GeneralTemplate](src/main/java/com/google/cloud/dataproc/templates/general/README.md)
 
@@ -113,6 +114,11 @@ Dataproc Templates (Java - Spark) submit jobs to Dataproc Serverless using [batc
         ```
         bin/start.sh -- --template PUBSUBTOBQ
         ```
+       
+   1. #### Executing PubSub to GCS template.
+       ```
+       bin/start.sh -- --template PUBSUBTOGCS
+       ```
 
     1. #### Executing GCS to BigQuery template.
         ```

--- a/java/README.md
+++ b/java/README.md
@@ -114,7 +114,7 @@ Dataproc Templates (Java - Spark) submit jobs to Dataproc Serverless using [batc
         ```
         bin/start.sh -- --template PUBSUBTOBQ
         ```
-       
+
    1. #### Executing PubSub to GCS template.
        ```
        bin/start.sh -- --template PUBSUBTOGCS

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,7 +26,6 @@
     <project.version>3.1</project.version>
     <junit-platform.version>5.7.2</junit-platform.version>
     <spotless-maven-plugin.version>2.1.0</spotless-maven-plugin.version>
-    <json.version>20211205$</json.version>
   </properties>
 
   <dependencies>
@@ -240,7 +239,7 @@
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>{json.version}</version>
+      <version>20211205</version>
     </dependency>
 
   </dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,6 +26,7 @@
     <project.version>3.1</project.version>
     <junit-platform.version>5.7.2</junit-platform.version>
     <spotless-maven-plugin.version>2.1.0</spotless-maven-plugin.version>
+    <json.version>20211205$</json.version>
   </properties>
 
   <dependencies>
@@ -236,6 +237,12 @@
       <artifactId>google-cloud-storage</artifactId>
       <version>${gcs.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>{json.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/java/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
@@ -35,7 +35,8 @@ public interface BaseTemplate {
     JDBCTOGCS,
     BIGQUERYTOGCS,
     GENERAL,
-    DATAPLEXGCSTOBQ
+    DATAPLEXGCSTOBQ,
+    PUBSUBTOGCS
   }
 
   default Properties getProperties() {

--- a/java/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
@@ -28,6 +28,7 @@ import com.google.cloud.dataproc.templates.hive.HiveToGCS;
 import com.google.cloud.dataproc.templates.jdbc.JDBCToBigQuery;
 import com.google.cloud.dataproc.templates.jdbc.JDBCToGCS;
 import com.google.cloud.dataproc.templates.pubsub.PubSubToBQ;
+import com.google.cloud.dataproc.templates.pubsub.PubSubToGCS;
 import com.google.cloud.dataproc.templates.s3.S3ToBigQuery;
 import com.google.cloud.dataproc.templates.util.PropertyUtil;
 import com.google.cloud.dataproc.templates.util.TemplateUtil;
@@ -57,6 +58,7 @@ public class DataProcTemplate {
           .put(TemplateName.HIVETOGCS, (args) -> new HiveToGCS())
           .put(TemplateName.HIVETOBIGQUERY, (args) -> new HiveToBigQuery())
           .put(TemplateName.PUBSUBTOBQ, (args) -> new PubSubToBQ())
+          .put(TemplateName.PUBSUBTOGCS, (args) -> new PubSubToGCS())
           .put(TemplateName.GCSTOBIGQUERY, (args) -> new GCStoBigquery())
           .put(TemplateName.BIGQUERYTOGCS, (args) -> new BigQueryToGCS())
           .put(TemplateName.S3TOBIGQUERY, (args) -> new S3ToBigQuery())

--- a/java/src/main/java/com/google/cloud/dataproc/templates/pubsub/PubSubToGCS.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/pubsub/PubSubToGCS.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.pubsub;
+
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.cloud.dataproc.templates.BaseTemplate;
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Bucket;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaRDD;
+import org.apache.spark.api.java.function.VoidFunction;
+import org.apache.spark.storage.StorageLevel;
+import org.apache.spark.streaming.Seconds;
+import org.apache.spark.streaming.api.java.JavaDStream;
+import org.apache.spark.streaming.api.java.JavaStreamingContext;
+import org.apache.spark.streaming.pubsub.PubsubUtils;
+import org.apache.spark.streaming.pubsub.SparkGCPCredentials;
+import org.apache.spark.streaming.pubsub.SparkPubsubMessage;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PubSubToGCS implements BaseTemplate {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(com.google.cloud.dataproc.templates.pubsub.PubSubToGCS.class);
+  private String inputProjectID;
+  private String pubsubInputSubscription;
+  private long timeoutMs;
+  private int streamingDuration;
+  private int totalReceivers;
+  private String outputProjectID;
+  private String gcsBucketName;
+  private int batchSize;
+  private String outputDataFormat;
+
+  public PubSubToGCS() {
+    inputProjectID = getProperties().getProperty(PUBSUB_GCS_INPUT_PROJECT_ID_PROP);
+    pubsubInputSubscription = getProperties().getProperty(PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP);
+    timeoutMs = Long.parseLong(getProperties().getProperty(PUBSUB_GCS_TIMEOUT_MS_PROP));
+    streamingDuration =
+        Integer.parseInt(getProperties().getProperty(PUBSUB_GCS_STREAMING_DURATION_SECONDS_PROP));
+    totalReceivers = Integer.parseInt(getProperties().getProperty(PUBSUB_GCS_TOTAL_RECEIVERS_PROP));
+    outputProjectID = getProperties().getProperty(PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP);
+    gcsBucketName = getProperties().getProperty(PUBSUB_GCS_BUCKET_NAME);
+    batchSize = Integer.parseInt(getProperties().getProperty(PUBSUB_GCS_BATCH_SIZE_PROP));
+    outputDataFormat = getProperties().getProperty(PUBSUB_GCS_OUTPUT_DATA_FORMAT);
+  }
+
+  @Override
+  public void runTemplate() {
+    if (StringUtils.isAllBlank(inputProjectID)
+        || StringUtils.isAllBlank(pubsubInputSubscription)
+        || StringUtils.isAllBlank(outputProjectID)
+        || StringUtils.isAllBlank(gcsBucketName)
+        || StringUtils.isAllBlank(outputDataFormat)) {
+      LOGGER.error(
+          "{},{},{},{},{} are required parameter. ",
+          PUBSUB_GCS_INPUT_PROJECT_ID_PROP,
+          PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP,
+          PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP,
+          PUBSUB_GCS_BUCKET_NAME,
+          PUBSUB_GCS_OUTPUT_DATA_FORMAT);
+      throw new IllegalArgumentException(
+          "Required parameters for PubSubToGCS not passed. "
+              + "Set mandatory parameter for PubSubToGCS template "
+              + "in resources/conf/template.properties file.");
+    }
+
+    JavaStreamingContext jsc = null;
+    LOGGER.info(
+        "Starting PubSub to GCS spark job with following parameters:"
+            + "1. {}:{}"
+            + "2. {}:{}"
+            + "3. {}:{}"
+            + "4. {},{}"
+            + "5. {},{}"
+            + "6. {},{}"
+            + "7. {},{}"
+            + "8. {},{}"
+            + "9. {},{}",
+        PUBSUB_GCS_INPUT_PROJECT_ID_PROP,
+        inputProjectID,
+        PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP,
+        pubsubInputSubscription,
+        PUBSUB_GCS_TIMEOUT_MS_PROP,
+        timeoutMs,
+        PUBSUB_GCS_STREAMING_DURATION_SECONDS_PROP,
+        streamingDuration,
+        PUBSUB_GCS_TOTAL_RECEIVERS_PROP,
+        totalReceivers,
+        PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP,
+        outputProjectID,
+        PUBSUB_GCS_BUCKET_NAME,
+        gcsBucketName,
+        PUBSUB_GCS_BATCH_SIZE_PROP,
+        batchSize,
+        PUBSUB_GCS_OUTPUT_DATA_FORMAT,
+        outputDataFormat);
+
+    try {
+      SparkConf sparkConf = new SparkConf().setAppName("PubSubToGCS Dataproc Job");
+      jsc = new JavaStreamingContext(sparkConf, Seconds.apply(streamingDuration));
+
+      JavaDStream<SparkPubsubMessage> stream = null;
+      for (int i = 0; i < totalReceivers; i += 1) {
+        JavaDStream<SparkPubsubMessage> pubSubReciever =
+            PubsubUtils.createStream(
+                jsc,
+                inputProjectID,
+                pubsubInputSubscription,
+                new SparkGCPCredentials.Builder().build(),
+                StorageLevel.MEMORY_AND_DISK_SER());
+        if (stream == null) {
+          stream = pubSubReciever;
+        } else {
+          stream = stream.union(pubSubReciever);
+        }
+      }
+
+      LOGGER.info("Writing data to output GCS Bucket: {}", gcsBucketName);
+      Storage storage = StorageOptions.getDefaultInstance().getService();
+      Bucket bucket = storage.get(gcsBucketName);
+      writeToGCS(stream, outputProjectID, gcsBucketName, batchSize, outputDataFormat, bucket);
+
+      jsc.start();
+      jsc.awaitTerminationOrTimeout(timeoutMs);
+
+      LOGGER.info("PubSubToGCS job completed.");
+      jsc.stop();
+
+    } catch (Throwable th) {
+      LOGGER.error("Exception in PubSubToGCS", th);
+      if (Objects.nonNull(jsc)) {
+        jsc.stop();
+      }
+    }
+  }
+
+  public static void writeToGCS(
+      JavaDStream<SparkPubsubMessage> pubSubStream,
+      String outputProjectID,
+      String gcsBucketName,
+      Integer batchSize,
+      String outputDataFormat,
+      Bucket bucket) {
+    pubSubStream.foreachRDD(
+        new VoidFunction<JavaRDD<SparkPubsubMessage>>() {
+          @Override
+          public void call(JavaRDD<SparkPubsubMessage> sparkPubsubMessageJavaRDD) throws Exception {
+            sparkPubsubMessageJavaRDD.foreachPartition(
+                new VoidFunction<Iterator<SparkPubsubMessage>>() {
+                  @Override
+                  public void call(Iterator<SparkPubsubMessage> sparkPubsubMessageIterator)
+                      throws Exception {
+                    if (Arrays.asList(PUBSUB_GCS_OUTPUT_FORMATS_ARRAY).contains(outputDataFormat)) {
+                      JSONArray jsonArr = new JSONArray();
+                      while (sparkPubsubMessageIterator.hasNext()) {
+                        SparkPubsubMessage message = sparkPubsubMessageIterator.next();
+                        if (outputDataFormat.equalsIgnoreCase(PUBSUB_GCS_AVRO_EXTENSION)) {
+                          LOGGER.info("PubSubToGCS message Avro start...");
+                          Blob blob =
+                              bucket.create(
+                                  PUBSUB_GCS_BUCKET_OUTPUT_PATH
+                                      + message.getMessageId()
+                                      + "."
+                                      + PUBSUB_GCS_AVRO_EXTENSION,
+                                  message.getData());
+                          LOGGER.info("PubSubToGCS message Avro end...");
+                        } else if (outputDataFormat.equalsIgnoreCase(PUBSUB_GCS_JSON_EXTENSION)) {
+                          LOGGER.info("PubSubToGCS message Json start...");
+                          JSONObject record = new JSONObject(new String(message.getData()));
+                          jsonArr.put(record);
+                          if (jsonArr.length() == batchSize && jsonArr.length() > 0) {
+                            bucket.create(
+                                PUBSUB_GCS_BUCKET_OUTPUT_PATH
+                                    + "batch_"
+                                    + System.nanoTime()
+                                    + "."
+                                    + PUBSUB_GCS_JSON_EXTENSION,
+                                jsonArr.toString().getBytes(UTF_8));
+                            jsonArr = new JSONArray();
+                          }
+                          LOGGER.info("PubSubToGCS message Json end...");
+                        }
+                      } // end while
+                      if (jsonArr.length() > 0
+                          && outputDataFormat.equalsIgnoreCase(PUBSUB_GCS_JSON_EXTENSION)) {
+                        bucket.create(
+                            PUBSUB_GCS_BUCKET_OUTPUT_PATH
+                                + "batch_"
+                                + System.nanoTime()
+                                + "."
+                                + PUBSUB_GCS_JSON_EXTENSION,
+                            jsonArr.toString().getBytes(UTF_8));
+                        jsonArr = new JSONArray();
+                      }
+                    } else {
+                      LOGGER.error(outputDataFormat + " is not supported...");
+                    }
+                  }
+                });
+          }
+        });
+  }
+}

--- a/java/src/main/java/com/google/cloud/dataproc/templates/pubsub/README.md
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/pubsub/README.md
@@ -35,3 +35,51 @@ pubsub.bq.output.table=<bq output table>
 ## Number of records to be written per message to BigQuery
 pubsub.bq.batch.size=1000
 ```
+## 2. Pub/Sub To GCS
+
+General Execution:
+
+```
+export PROJECT=<gcp-project-id>
+export GCP_PROJECT=<gcp-project-id>
+export REGION=<gcp-project-region>
+export GCS_STAGING_LOCATION=<gcs-bucket-staging-folder-path>
+# Set optional environment variables.
+export SUBNET=<gcp-project-dataproc-clusters-subnet>
+# ID of Dataproc cluster running permanent history server to access historic logs.
+#export HISTORY_SERVER_CLUSTER=<gcp-project-dataproc-phs-server-id>
+
+# The submit spark options must be seperated with a "--" from the template options
+bin/start.sh \
+-- \
+--template PUBSUBTOGCS \
+--templateProperty pubsubtogcs.input.project.id=$GCP_PROJECT \
+--templateProperty pubsubtogcs.input.subscription=<pubsub-topic-subscription-name> \
+--templateProperty pubsubtogcs.gcs.output.project.id=$GCP_PROJECT \
+--templateProperty pubsubtogcs.gcs.bucket.name=<gcs-bucket-name> \
+--templateProperty pubsubtogcs.gcs.output.data.format=AVRO or JSON (based on pubsub topic configuration) \
+```
+
+### Configurable Parameters
+Update Following properties in  [template.properties](../../../../../../../resources/template.properties) file:
+```
+# PubSub to GCS
+## Project that contains the input Pub/Sub subscription to be read
+pubsubtogcs.input.project.id=yadavaja-sandbox
+## PubSub subscription name
+pubsubtogcs.input.subscription=
+## Stream timeout, for how long the subscription will be read
+pubsubtogcs.timeout.ms=60000
+## Streaming duration, how often wil writes to GCS be triggered
+pubsubtogcs.streaming.duration.seconds=15
+## Number of streams that will read from Pub/Sub subscription in parallel
+pubsubtogcs.total.receivers=5
+## Project that contains the GCS output
+pubsubtogcs.gcs.output.project.id=
+## GCS bucket URL
+pubsubtogcs.gcs.bucket.name=
+## Number of records to be written per message to GCS
+pubsubtogcs.batch.size=1000
+## PubSub to GCS supported formats are: AVRO, JSON
+pubsubtogcs.gcs.output.data.format=
+```

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -195,6 +195,29 @@ public interface TemplateConstants {
 
   String BQ_GCS_OUTPUT_LOCATION = "bigquery.gcs.output.location";
 
+  /** PubSubToGCS Template configs. */
+  // Project that contains the input PubSub subscription to be read
+  String PUBSUB_GCS_INPUT_PROJECT_ID_PROP = "pubsubtogcs.input.project.id";
+  // PubSub subscription name
+  String PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP = "pubsubtogcs.input.subscription";
+  // Stream timeout
+  String PUBSUB_GCS_TIMEOUT_MS_PROP = "pubsubtogcs.timeout.ms";
+  // Streaming duration
+  String PUBSUB_GCS_STREAMING_DURATION_SECONDS_PROP = "pubsubtogcs.streaming.duration.seconds";
+  // Number of receivers
+  String PUBSUB_GCS_TOTAL_RECEIVERS_PROP = "pubsubtogcs.total.receivers";
+  // Project that contains the GCS output
+  String PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP = "pubsubtogcs.gcs.output.project.id";
+  // GCS bucket URL
+  String PUBSUB_GCS_BUCKET_NAME = "pubsubtogcs.gcs.bucket.name";
+  // Number of records to be written per message to GCS
+  String PUBSUB_GCS_BATCH_SIZE_PROP = "pubsubtogcs.batch.size";
+  String PUBSUB_GCS_BUCKET_OUTPUT_PATH = "output/";
+  String PUBSUB_GCS_OUTPUT_DATA_FORMAT = "pubsubtogcs.gcs.output.data.format";
+  String[] PUBSUB_GCS_OUTPUT_FORMATS_ARRAY = {"AVRO", "JSON"};
+  String PUBSUB_GCS_AVRO_EXTENSION = "avro";
+  String PUBSUB_GCS_JSON_EXTENSION = "json";
+
   /** Dataplex GCS to BQ */
   String DATAPLEX_GCS_BQ_TARGET_DATASET = "dataplex.gcs.bq.target.dataset";
 

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -214,7 +214,6 @@ public interface TemplateConstants {
   String PUBSUB_GCS_BATCH_SIZE_PROP = "pubsubtogcs.batch.size";
   String PUBSUB_GCS_BUCKET_OUTPUT_PATH = "output/";
   String PUBSUB_GCS_OUTPUT_DATA_FORMAT = "pubsubtogcs.gcs.output.data.format";
-  String[] PUBSUB_GCS_OUTPUT_FORMATS_ARRAY = {"AVRO", "JSON"};
   String PUBSUB_GCS_AVRO_EXTENSION = "avro";
   String PUBSUB_GCS_JSON_EXTENSION = "json";
 

--- a/java/src/main/resources/template.properties
+++ b/java/src/main/resources/template.properties
@@ -142,6 +142,26 @@ gcs.spanner.output.table=<spanner table id>
 gcs.spanner.output.saveMode=<Append|Overwrite|ErrorIfExists|Ignore>
 gcs.spanner.output.primaryKey=<column[(,column)*] - primary key columns needed when creating the table>
 
+# PubSub to GCS
+## Project that contains the input Pub/Sub subscription to be read
+pubsubtogcs.input.project.id=yadavaja-sandbox
+## PubSub subscription name
+pubsubtogcs.input.subscription=
+## Stream timeout, for how long the subscription will be read
+pubsubtogcs.timeout.ms=60000
+## Streaming duration, how often wil writes to GCS be triggered
+pubsubtogcs.streaming.duration.seconds=15
+## Number of streams that will read from Pub/Sub subscription in parallel
+pubsubtogcs.total.receivers=5
+## Project that contains the GCS output
+pubsubtogcs.gcs.output.project.id=
+## GCS bucket URL
+pubsubtogcs.gcs.bucket.name=
+## Number of records to be written per message to GCS
+pubsubtogcs.batch.size=1000
+## PubSub to GCS supported formats are: AVRO, JSON
+pubsubtogcs.gcs.output.data.format=
+
 # Dataplex GCS to BQ
 dataplex.gcs.bq.target.dataset=<bq target dataset>
 dataplex.gcs.bq.save.mode="errorifexists"

--- a/java/src/test/java/com/google/cloud/dataproc/templates/pubsub/PubSubToGCSTest.java
+++ b/java/src/test/java/com/google/cloud/dataproc/templates/pubsub/PubSubToGCSTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.pubsub;
+
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.cloud.dataproc.templates.util.PropertyUtil;
+import java.util.stream.Stream;
+import org.apache.spark.sql.SparkSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PubSubToGCSTest {
+
+  private PubSubToGCS pubSubToGCS;
+
+  @BeforeEach
+  void setUp() {
+    PropertyUtil.getProperties().setProperty(PUBSUB_GCS_INPUT_PROJECT_ID_PROP, "some value");
+    PropertyUtil.getProperties().setProperty(PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP, "some value");
+    PropertyUtil.getProperties().setProperty(PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP, "some value");
+    PropertyUtil.getProperties().setProperty(PUBSUB_GCS_BUCKET_NAME, "some value");
+    PropertyUtil.getProperties().setProperty(PUBSUB_GCS_OUTPUT_DATA_FORMAT, "some value");
+    SparkSession spark = SparkSession.builder().master("local").getOrCreate();
+  }
+
+  @ParameterizedTest
+  @MethodSource("propertyKeys")
+  void runTemplateWithValidParameters(String propKey) {
+
+    PropertyUtil.getProperties().setProperty(propKey, "someValue");
+
+    pubSubToGCS = new PubSubToGCS();
+    assertDoesNotThrow(pubSubToGCS::runTemplate);
+  }
+
+  @ParameterizedTest
+  @MethodSource("propertyKeys")
+  void runTemplateWithInvalidParameters(String propKey) {
+    PropertyUtil.getProperties().setProperty(propKey, "");
+    pubSubToGCS = new PubSubToGCS();
+
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> pubSubToGCS.runTemplate());
+    assertEquals(
+        "Required parameters for PubSubToGCS not passed. "
+            + "Set mandatory parameter for PubSubToGCS template "
+            + "in resources/conf/template.properties file.",
+        exception.getMessage());
+  }
+
+  static Stream<String> propertyKeys() {
+    return Stream.of(
+        PUBSUB_GCS_INPUT_PROJECT_ID_PROP,
+        PUBSUB_GCS_INPUT_SUBSCRIPTION_PROP,
+        PUBSUB_GCS_OUTPUT_PROJECT_ID_PROP,
+        PUBSUB_GCS_BUCKET_NAME,
+        PUBSUB_GCS_OUTPUT_DATA_FORMAT);
+  }
+}


### PR DESCRIPTION
Hi,
Please ignore the previous pull request https://github.com/GoogleCloudPlatform/dataproc-templates/pull/88

I have addressed all the previous review comments in this new pull request except the following:
 - PubSubToGCS:runTemplate()  needs to have try-catch block because of the presence of JavaStreamingContext.awaitTerminationOrTimeout() method
 -  If pubsub messages are coming in JSON format then the multuple pubsub records will be merged into a single file before writing to GCS. Same support needs to be added for Avro and I can  research it and do it in a later point.
 
Testing:
Successfully tested Avro and Json formats and output data was written to gs://pubsubtogcs_dev/output folder.