### PR TITLE
removing support for migration of several entities in a single run

### DIFF
--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
@@ -19,39 +19,52 @@ bin/start.sh \
 --templateProperty gcs.bigquery.temp.bucket.name=<temp-bucket-name> \
 --templateProperty dataplex.gcs.bq.save.mode="append" \
 --templateProperty dataplex.gcs.bq.incremental.partition.copy="yes" \
---dataplexAsset "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/asset/{asset_id}" \
+--dataplexEntity "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}" \
 --partitionField "partition_field" \
 --partitionType "DAY" \
 --customSqlGcsPath "gs://bucket/path/to/custom_sql.sql" 
 ```
 
 ### Template properties
-`dataplex.gcs.bq.save.mode` specifies how to handle existing data in BigQuery if present. 
-Can be any of the following: `errorifexists`, `append` ,`overwrite`, `ignore`. Defaults to `errorifexists` \
+`project.id` id of the GCP project where the target BigQuery dataset and custom 
+SQL file should be located
 
-`dataplex.gcs.bq.incremental.partition.copy` specifies if the template should copy new partitions only or all the partitions. 
-If set to `no` existing partitions, if found will be overwritten. Can be any of the following `yes`, `no`. Defaults to `yes`
+`dataplex.gcs.bq.target.dataset` name of the target BigQuery dataset where the 
+Dataplex GCS asset will be migrated to
 
+`gcs.bigquery.temp.bucket.name` the GCS bucket that temporarily holds the data 
+before it is loaded to BigQuery
+
+`dataplex.gcs.bq.save.mode` specifies how to handle existing data in BigQuery 
+if present. 
+Can be any of the following: `errorifexists`, `append` ,`overwrite`, `ignore`. 
+Defaults to `errorifexists` \
+
+`dataplex.gcs.bq.incremental.partition.copy` specifies if the template should 
+copy new partitions only or all the partitions. If set to `no` existing 
+partitions, if found will be overwritten. Can be any of the following `yes`, 
+`no`. Defaults to `yes`
 
 ### Arguments
-`--dataplexAsset` asset to be copied to BigQuery. If provided, each GCS table of the asset will be loaded. \
-Example: `--dataplexAsset projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/asset/{asset_id}`
+`--dataplexEntity` Dataplex GCS table to load in BigQuery \
+Example: `--dataplexEntityList "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}"`
 
-`--dataplexEntityList` list of GCS tables to load in BigQuery, separated by commas. \
-Example: `--dataplexEntityList "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1},projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_2}"`
-
-`--partitionField` if field is specified together with `partitionType`, the table is partitioned by this field. The field must be a top-level TIMESTAMP or DATE field.
+`--partitionField` if field is specified together with `partitionType`, the 
+table is partitioned by this field. The field must be a top-level TIMESTAMP 
+or DATE field.
 
 `--partitionType` Supported types are: `HOUR`, `DAY`, `MONTH`, `YEAR`
 
 ### Custom SQL 
 
-Optionally a custom SQL can be provided to filter the data that will be copied to BigQuery. \
+Optionally a custom SQL can be provided to filter the data that will be copied 
+to BigQuery. \
 The template will read from a GCS file with the custom sql string.
 
 The path to this file must be provided with the option `--customSqlGcsPath`. 
 
-Custom SQL must reference `__table__` in the FROM clause as shown in the following example:
+Custom SQL must reference `__table__` in the FROM clause as shown in the 
+following example:
 
 ```
 SELECT 


### PR DESCRIPTION
Originally the template could migrate several tables in a single batch.
This PR simplifies the template by limiting it's functionality to a single table per run.

This is because handling table specific arguments while migrating several tables in a single batch was adding unnecessary complexity. 