### PR TITLE
Dataplex bugs fixes & new features 

### DIFF
--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
@@ -55,6 +55,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
   public static String ENTITY_OPTION = "dataplexEntity";
   public static String PARTITION_FIELD_OPTION = "partitionField";
   public static String PARTITION_TYPE_OPTION = "partitionType";
+  public static String TARGET_TABLE_NAME_OPTION = "targetTableName";
   public static String INCREMENTAL_PARTITION_COPY_NO = "no";
   public static String BQ_TABLE_NAME_FORMAT = "%s.%s.%s";
   public static String SPARK_SQL_SELECT_STAR = "*";
@@ -99,11 +100,16 @@ public class DataplexGCStoBQ implements BaseTemplate {
   private String incrementalParittionCopy;
 
   public DataplexGCStoBQ(
-      String customSqlGCSPath, String entity, String partitionField, String partitionType) {
+      String customSqlGCSPath,
+      String entity,
+      String partitionField,
+      String partitionType,
+      String targetTableName) {
     this.customSqlGCSPath = customSqlGCSPath;
     this.entity = entity;
     this.partitionField = partitionField;
     this.partitionType = partitionType;
+    this.targetTableName = targetTableName;
 
     projectId = getProperties().getProperty(PROJECT_ID_PROP);
     targetDataset = getProperties().getProperty(DATAPLEX_GCS_BQ_TARGET_DATASET);
@@ -122,7 +128,9 @@ public class DataplexGCStoBQ implements BaseTemplate {
     String entity = cmd.getOptionValue(ENTITY_OPTION);
     String partitionField = cmd.getOptionValue(PARTITION_FIELD_OPTION);
     String partitionType = cmd.getOptionValue(PARTITION_TYPE_OPTION);
-    return new DataplexGCStoBQ(customSqlGCSPath, entity, partitionField, partitionType);
+    String targetTableName = cmd.getOptionValue("targetTableName");
+    return new DataplexGCStoBQ(
+        customSqlGCSPath, entity, partitionField, partitionType, targetTableName);
   }
 
   /**
@@ -176,12 +184,20 @@ public class DataplexGCStoBQ implements BaseTemplate {
             .withDescription("BigQuery partitionType")
             .create();
 
+    Option targetTableName =
+        OptionBuilder.withLongOpt(TARGET_TABLE_NAME_OPTION)
+            .hasArgs(1)
+            .isRequired(false)
+            .withDescription("BigQuery table name where data will be written to")
+            .create();
+
     options =
         new Options()
             .addOption(entityListOption)
             .addOption(customSQLFileOption)
             .addOption(partitionField)
-            .addOption(partitionType);
+            .addOption(partitionType)
+            .addOption(targetTableName);
     try {
       return parser.parse(options, args, true);
     } catch (ParseException e) {
@@ -382,13 +398,14 @@ public class DataplexGCStoBQ implements BaseTemplate {
       // TODO: refactor the following DataplexUtil avoid calling the same API method more than once
       this.entityBasePath = DataplexUtil.getBasePathEntityData(entity);
       this.inputFileFormat = DataplexUtil.getInputFileFormat(entity);
-      if (this.inputFileFormat.equals("csv")) {
+      if (this.inputFileFormat.equals(GCS_BQ_CSV_FORMAT)) {
         this.inputCSVDelimiter = DataplexUtil.getInputCSVDelimiter(entity);
       }
-      this.targetTableName = entity.split(FORWARD_SLASH)[entity.split(FORWARD_SLASH).length - 1];
+      if (this.targetTableName == null) {
+        this.targetTableName = entity.split(FORWARD_SLASH)[entity.split(FORWARD_SLASH).length - 1];
+      }
       this.targetTable =
           String.format(BQ_TABLE_NAME_FORMAT, projectId, targetDataset, targetTableName);
-      LOGGER.info("Processing entity: {}", entity);
 
       List<String> partitionKeysList = DataplexUtil.getPartitionKeyList(entity);
       List<String> partitionsListWithLocationAndKeys =

--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
@@ -130,7 +130,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
    *
    * @throws Exception if values no value is passed for --dataplexEntity
    */
-  private void checkInput() throws DataprocTemplateException, IOException {
+  private void checkInput() {
     if (entity != null) {
       this.entity = entity;
     } else {
@@ -408,19 +408,20 @@ public class DataplexGCStoBQ implements BaseTemplate {
 
       // load data from each partition
       Dataset<Row> newPartitionsDS = getNewPartitionsDS(newPartitionsPathsDS);
-      newPartitionsDS.printSchema();
-
-      newPartitionsDS = DataplexUtil.castDatasetToDataplexSchema(newPartitionsDS, entity);
-
-      newPartitionsDS = applyCustomSql(newPartitionsDS);
-
-      writeToBQ(newPartitionsDS);
+      if (newPartitionsDS != null) {
+        newPartitionsDS = DataplexUtil.castDatasetToDataplexSchema(newPartitionsDS, entity);
+        newPartitionsDS = applyCustomSql(newPartitionsDS);
+        writeToBQ(newPartitionsDS);
+      } else {
+        LOGGER.info("No new partitions found");
+      }
 
     } catch (Throwable th) {
       LOGGER.error("Exception in DataplexGCStoBQ", th);
       if (Objects.nonNull(spark)) {
         spark.stop();
       }
+      throw new DataprocTemplateException(th.getMessage());
     }
   }
 }

--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
@@ -22,6 +22,7 @@ bin/start.sh \
 --dataplexEntity "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}" \
 --partitionField "partition_field" \
 --partitionType "DAY" \
+--targetTableName "table_name" \
 --customSqlGcsPath "gs://bucket/path/to/custom_sql.sql" 
 ```
 
@@ -53,7 +54,10 @@ Example: `--dataplexEntityList "projects/{project_number}/locations/{location_id
 table is partitioned by this field. The field must be a top-level TIMESTAMP 
 or DATE field.
 
-`--partitionType` Supported types are: `HOUR`, `DAY`, `MONTH`, `YEAR`
+`--partitionType` supported types are: `HOUR`, `DAY`, `MONTH`, `YEAR`
+
+`--targetTableName` name of the table where data will be written to. If this 
+argument is not specified the name of the entity will be used as table name
 
 ### Custom SQL 
 

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/DataplexUtil.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/DataplexUtil.java
@@ -308,7 +308,7 @@ public class DataplexUtil {
     dataplexTypeToSparkType.put(DATAPLEX_BYTE_DATA_TYPE_NAME, DataTypes.ByteType);
     dataplexTypeToSparkType.put(DATAPLEX_INT16_DATA_TYPE_NAME, DataTypes.IntegerType);
     dataplexTypeToSparkType.put(DATAPLEX_INT32_DATA_TYPE_NAME, DataTypes.IntegerType);
-    dataplexTypeToSparkType.put(DATAPLEX_INT64_DATA_TYPE_NAME, DataTypes.IntegerType);
+    dataplexTypeToSparkType.put(DATAPLEX_INT64_DATA_TYPE_NAME, DataTypes.LongType);
     dataplexTypeToSparkType.put(DATAPLEX_FLOAT_DATA_TYPE_NAME, DataTypes.FloatType);
     dataplexTypeToSparkType.put(DATAPLEX_DOUBLE_DATA_TYPE_NAME, DataTypes.DoubleType);
     dataplexTypeToSparkType.put(DATAPLEX_DECIMAL_DATA_TYPE_NAME, DataTypes.createDecimalType());

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/DataprocTemplateException.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/DataprocTemplateException.java
@@ -15,7 +15,7 @@
  */
 package com.google.cloud.dataproc.templates.util;
 
-public class DataprocTemplateException extends Exception {
+public class DataprocTemplateException extends RuntimeException {
 
   /**
    * Constructs a new DataprocTemplateException with null as its detail message. The cause is not


### PR DESCRIPTION
Fixing the following bugs:

- The template was returning a successful exit code even if it failed 
- The template would fail when no new data was available in dataplex
- Dataplex INT64 fields where cast into Spark IntegerType instead of LongType

Adding the following Feature:
- User can now specify the target table name