### PR TITLE
added python medium blog links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,16 @@ Please refer to the [Dataproc Templates (Java - Spark) README](/java/README.md) 
 
 ## Dataproc Templates (Python - PySpark)
 Please refer to the [Dataproc Templates (Python - PySpark) README](/python/README.md) for more information
-* [GCSToBigQuery](/python/dataproc_templates/gcs/README.md)
+
+* [BigQueryToGCS](/python/dataproc_templates/bigquery/README.md) (blogpost [link](https://medium.com/google-cloud/moving-data-from-bigquery-to-gcs-using-gcp-dataproc-serverless-and-pyspark-f6481b86bcd1))
+* [GCSToBigQuery](/python/dataproc_templates/gcs/README.md) (blogpost [link](https://medium.com/@ppaglilla/getting-started-with-dataproc-serverless-pyspark-templates-e32278a6a06e))
 * [GCSToBigTable](/python/dataproc_templates/gcs/README.md)
 * [GCSToJDBC](/python/dataproc_templates/gcs/README.md)
-* [BigQueryToGCS](/python/dataproc_templates/bigquery/README.md)
 * [HiveToBigQuery](/python/dataproc_templates/hive/README.md)
 * [HiveToGCS](/python/dataproc_templates/hive/README.md)
-* [TextToBiqQuery](/python/dataproc_templates/gcs/README.md)
 * [HbaseToGCS](/python/dataproc_templates/hbase/README.md)
+* [TextToBiqQuery](/python/dataproc_templates/gcs/README.md)
+
 
 ## Getting Started
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,14 +2,14 @@
 
 # Dataproc Templates (Python - PySpark)
 
-* [GCSToBigQuery](/python/dataproc_templates/gcs/README.md)
+* [BigQueryToGCS](/python/dataproc_templates/bigquery/README.md) (blogpost [link](https://medium.com/google-cloud/moving-data-from-bigquery-to-gcs-using-gcp-dataproc-serverless-and-pyspark-f6481b86bcd1))
+* [GCSToBigQuery](/python/dataproc_templates/gcs/README.md) (blogpost [link](https://medium.com/@ppaglilla/getting-started-with-dataproc-serverless-pyspark-templates-e32278a6a06e))
 * [GCSToBigTable](/python/dataproc_templates/gcs/README.md)
 * [GCSToJDBC](/python/dataproc_templates/gcs/README.md)
-* [BigQueryToGCS](/python/dataproc_templates/bigquery/README.md)
 * [HiveToBigQuery](/python/dataproc_templates/hive/README.md)
 * [HiveToGCS](/python/dataproc_templates/hive/README.md)
-* [TextToBigQuery](/python/dataproc_templates/gcs/README.md)
 * [HbaseToGCS](/python/dataproc_templates/hbase/README.md)
+* [TextToBigQuery](/python/dataproc_templates/gcs/README.md)
 
 Dataproc Templates (Python - PySpark) submit jobs to Dataproc Serverless using [batches submit pyspark](https://cloud.google.com/sdk/gcloud/reference/dataproc/batches/submit/pyspark).
 


### PR DESCRIPTION
Added medium blog links for BigqueryToGCS and GCStoBigquery (created by Pablo).

Closes #131 