### PR TITLE
Kafka to gcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Google is providing this collection of pre-implemented Dataproc templates as a r
 * [S3ToBigQuery](src/main/java/com/google/cloud/dataproc/templates/s3/README.md)
 * [JDBCToBigQuery](src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
 * [JDBCToGCS](src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md)
+* [KafkaToGCS](src/main/java/com/google/cloud/dataproc/templates/kafka/README.md)
 * [WordCount](src/main/java/com/google/cloud/dataproc/templates/word/WordCount.java)
 * [GeneralTemplate](src/main/java/com/google/cloud/dataproc/templates/general/README.md)
 

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
       <artifactId>hadoop-common</artifactId>
       <version>3.2.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <version>2.1.9</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,12 +104,20 @@
       <scope>provided</scope>
     </dependency>
 
+    <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql-kafka-0-10 -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql-kafka-0-10_${scala.binary.version}</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-streaming_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
     </dependency>
+
 
     <dependency>
       <groupId>org.apache.bahir</groupId>

--- a/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
@@ -35,7 +35,7 @@ public interface BaseTemplate {
     JDBCTOGCS,
     BIGQUERYTOGCS,
     GENERAL,
-    KAFKATOGCS;
+    KAFKATOGCS
   }
 
   default Properties getProperties() {

--- a/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/BaseTemplate.java
@@ -34,7 +34,8 @@ public interface BaseTemplate {
     JDBCTOBIGQUERY,
     JDBCTOGCS,
     BIGQUERYTOGCS,
-    GENERAL
+    GENERAL,
+    KAFKATOGCS;
   }
 
   default Properties getProperties() {

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaReader.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaReader.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.kafka;
+
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.KAFKA_BOOTSTRAP_SERVERS;
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.KAFKA_MESSAGE_FORMAT;
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.KAFKA_SCHEMA_URL;
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.KAFKA_STARTING_OFFSET;
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.KAFKA_TOPIC;
+
+import com.google.cloud.dataproc.templates.util.ReadSchemaUtil;
+import java.util.Properties;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.functions;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaReader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaReader.class);
+
+  private String kakfaMessageFormat;
+  private String kafkaBootstrapServers;
+  private String kafkaTopic;
+  private String kafkaStartingOffsets;
+  private String kafkaSchemaUrl;
+
+  public Dataset<Row> readKafkaTopic(SparkSession spark, Properties prop) {
+
+    kafkaBootstrapServers = prop.getProperty(KAFKA_BOOTSTRAP_SERVERS);
+    kafkaTopic = prop.getProperty(KAFKA_TOPIC);
+    kakfaMessageFormat = prop.getProperty(KAFKA_MESSAGE_FORMAT);
+    kafkaStartingOffsets = prop.getProperty(KAFKA_STARTING_OFFSET);
+    kafkaSchemaUrl = prop.getProperty(KAFKA_SCHEMA_URL);
+
+    Dataset<Row> inputData =
+        spark
+            .readStream()
+            .format("kafka")
+            .option("kafka.bootstrap.servers", kafkaBootstrapServers)
+            .option("subscribe", kafkaTopic)
+            .option("startingOffsets", kafkaStartingOffsets)
+            .option("failOnDataLoss", "false")
+            .load();
+
+    // check on memory constraints
+
+    Dataset<Row> processedData = null;
+
+    switch (kakfaMessageFormat) {
+      case "bytes":
+        processedData = processBytesMessage(inputData);
+        break;
+
+      case "json":
+        LOGGER.debug("Processing JSON Message");
+        processedData = processJsonMessage(inputData);
+        break;
+    }
+
+    return processedData;
+  }
+
+  private Dataset<Row> processJsonMessage(Dataset<Row> df) {
+
+    StructType schema = ReadSchemaUtil.readSchema(kafkaSchemaUrl);
+
+    Dataset<Row> processedDF =
+        df.selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+            .select(
+                functions.col("key"),
+                functions.from_json(functions.col("value"), schema).alias("json_value"))
+            .select("key", "json_value.*");
+
+    return processedDF;
+  }
+
+  private Dataset<Row> processBytesMessage(Dataset<Row> df) {
+
+    Dataset<Row> processedDF =
+        df.withColumn("key", functions.col("key").cast(DataTypes.StringType))
+            .withColumn("value", functions.col("value").cast(DataTypes.StringType));
+
+    return processedDF;
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCS.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCS.java
@@ -28,14 +28,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Spark job to move data or/and schema from Kafka topic to GCS. This template can be configured
- * to run in few different modes. In default mode kafka.gcs.output.mode is set to "append".
- * This will write only the new row in streaming DataFrame/Dataset to write to sink. Other possible values for this
- * property are:
- * 1. Complete: All the rows in the streaming DataFrame/Dataset will be written to the sink every time there are some updates.
- * 2. Update: Only the rows that were updated in the streaming DataFrame/Dataset will be written to the sink every time there are some updates.
- * For detailed list of properties
- * refer "KafkaToGCS Template properties" section in resources/template.properties file.
+ * Spark job to move data or/and schema from Kafka topic to GCS. This template can be configured to
+ * run in few different modes. In default mode kafka.gcs.output.mode is set to "append". This will
+ * write only the new row in streaming DataFrame/Dataset to write to sink. Other possible values for
+ * this property are: 1. Complete: All the rows in the streaming DataFrame/Dataset will be written
+ * to the sink every time there are some updates. 2. Update: Only the rows that were updated in the
+ * streaming DataFrame/Dataset will be written to the sink every time there are some updates. For
+ * detailed list of properties refer "KafkaToGCS Template properties" section in
+ * resources/template.properties file.
  */
 public class KafkaToGCS implements BaseTemplate {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaToGCS.class);
@@ -50,18 +50,14 @@ public class KafkaToGCS implements BaseTemplate {
 
   public KafkaToGCS() {
     gcsOutputLocation = getProperties().getProperty(KAFKA_GCS_OUTPUT_LOCATION);
-    gcsOutputFormat =
-        getProperties().getProperty(KAFKA_GCS_OUTPUT_FORMAT, KAFKA_GCS_OUTPUT_FORMAT_DEFAULT);
+    gcsOutputFormat = getProperties().getProperty(KAFKA_GCS_OUTPUT_FORMAT);
     kafkaBootstrapServers = getProperties().getProperty(KAFKA_GCS_BOOTSTRAP_SERVERS);
     kafkaTopic = getProperties().getProperty(KAFKA_GCS_TOPIC);
     gcsCheckpointLocation = gcsOutputLocation.concat("/checkpoint/");
-    kafkaStartingOffsets =
-        getProperties().getProperty(KAFKA_GCS_STARTING_OFFSET, KAFKA_GCS_STARTING_OFFSET_DEFAULT);
-    kafkaOutputMode =
-        getProperties().getProperty(KAFKA_GCS_OUTPUT_MODE, KAFKA_GCS_OUTPUT_MODE_DEFAULT);
+    kafkaStartingOffsets = getProperties().getProperty(KAFKA_GCS_STARTING_OFFSET);
+    kafkaOutputMode = getProperties().getProperty(KAFKA_GCS_OUTPUT_MODE);
     kafkaAwaitTerminationTimeout =
-        Long.valueOf(
-            getProperties().getProperty(KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT, KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT_DEFAULT));
+        Long.valueOf(getProperties().getProperty(KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT));
   }
 
   @Override

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCS.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCS.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.kafka;
+
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.*;
+
+import com.google.cloud.dataproc.templates.BaseTemplate;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.types.DataTypes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Spark job to move data or/and schema from Hive table to BigQuery. This template can be configured
+ * to run in few different modes. In default mode hivetobq.append.mode is set to ErrorIfExists. This
+ * will cause failure if target BigQuery table already exists. Other possible values for this
+ * property are: 1. Append 2. Overwrite 3. ErrorIfExists 4. Ignore For detailed list of properties
+ * refer "HiveToBQ Template properties" section in resources/template.properties file.
+ */
+public class KafkaToGCS implements BaseTemplate {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaToGCS.class);
+  private String gcsOutputLocation;
+  private String gcsOutputFormat;
+  private String kafkaBootstrapServers;
+  private String kafkaTopic;
+  private String gcsCheckpointLocation;
+  private String kafkaStartingOffsets;
+  private String kafkaOutputMode;
+  private Long kafkaAwaitTimeout;
+
+  public KafkaToGCS() {
+    gcsOutputLocation = getProperties().getProperty(KAFKA_GCS_OUTPUT_LOCATION);
+    gcsOutputFormat =
+        getProperties().getProperty(KAFKA_GCS_OUTPUT_FORMAT, KAFKA_GCS_OUTPUT_FORMAT_DEFAULT);
+    kafkaBootstrapServers = getProperties().getProperty(KAFKA_GCS_BOOTSTRAP_SERVERS);
+    kafkaTopic = getProperties().getProperty(KAFKA_GCS_TOPIC);
+    gcsCheckpointLocation = gcsOutputLocation.concat("/checkpoint/");
+    kafkaStartingOffsets =
+        getProperties().getProperty(KAFKA_GCS_STARTING_OFFSET, KAFKA_GCS_STARTING_OFFSET_DEFAULT);
+    kafkaOutputMode =
+        getProperties().getProperty(KAFKA_GCS_OUTPUT_MODE, KAFKA_GCS_OUTPUT_MODE_DEFAULT);
+    kafkaAwaitTimeout =
+        Long.valueOf(
+            getProperties().getProperty(KAFKA_GCS_AWAIT_TIMEOUT, KAFKA_GCS_AWAIT_TIMEOUT_DEFAULT));
+  }
+
+  @Override
+  public void runTemplate() {
+    if (StringUtils.isAllBlank(gcsOutputLocation)
+        || StringUtils.isAllBlank(kafkaBootstrapServers)
+        || StringUtils.isAllBlank(kafkaTopic)) {
+      LOGGER.error(
+          "{},{},{} is required parameter. ",
+          KAFKA_GCS_OUTPUT_LOCATION,
+          KAFKA_GCS_BOOTSTRAP_SERVERS,
+          KAFKA_GCS_TOPIC);
+      throw new IllegalArgumentException(
+          "Required parameters for KafkaToGCS not passed. "
+              + "Set mandatory parameter for KafkaToGCS template "
+              + "in resources/conf/template.properties file.");
+    }
+
+    SparkSession spark = null;
+    LOGGER.info(
+        "Starting Kafka to GCS spark job with following parameters:"
+            + "1. {}:{}"
+            + "2. {}:{}"
+            + "3. {}:{}"
+            + "4. {},{}"
+            + "5. {},{}"
+            + "6. {},{}"
+            + "7, {},{}",
+        KAFKA_GCS_OUTPUT_LOCATION,
+        gcsOutputLocation,
+        KAFKA_GCS_OUTPUT_FORMAT,
+        gcsOutputFormat,
+        KAFKA_GCS_BOOTSTRAP_SERVERS,
+        kafkaBootstrapServers,
+        KAFKA_GCS_TOPIC,
+        kafkaTopic,
+        KAFKA_GCS_STARTING_OFFSET,
+        kafkaStartingOffsets,
+        KAFKA_GCS_OUTPUT_MODE,
+        kafkaOutputMode,
+        KAFKA_GCS_AWAIT_TIMEOUT,
+        kafkaAwaitTimeout);
+
+    try {
+      // Initialize Spark session
+      spark = SparkSession.builder().appName("Spark KafkaToGCS Job").getOrCreate();
+
+      LOGGER.debug("added jars : {}", spark.sparkContext().addedJars().keys());
+
+      /** Read Input data from Hive table */
+      Dataset<Row> inputData =
+          spark
+              .readStream()
+              .format("kafka")
+              .option("kafka.bootstrap.servers", kafkaBootstrapServers)
+              .option("subscribe", kafkaTopic)
+              .option("startingOffsets", kafkaStartingOffsets)
+              .option("failOnDataLoss", "false")
+              .load();
+
+      Dataset<Row> processedData;
+
+      // Convert the key and value from kafka message to String
+      processedData =
+          inputData
+              .withColumn("key", inputData.col("key").cast(DataTypes.StringType))
+              .withColumn("value", inputData.col("value").cast(DataTypes.StringType));
+
+      // Write the output to GCS location
+      processedData
+          .writeStream()
+          .format(gcsOutputFormat)
+          .outputMode(kafkaOutputMode)
+          .option("checkpointLocation", gcsCheckpointLocation)
+          .option("path", gcsOutputLocation)
+          .start()
+          .awaitTermination(kafkaAwaitTimeout);
+
+      LOGGER.info("KakfaToGCS job completed.");
+      spark.stop();
+    } catch (Throwable th) {
+      LOGGER.error("Exception in KakfaToGCS", th);
+      if (Objects.nonNull(spark)) {
+        spark.stop();
+      }
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
@@ -1,0 +1,33 @@
+## 1. Kafka To GCS
+
+General Execution:
+
+```
+GCP_PROJECT=<gcp-project-id> \
+REGION=<region>  \
+SUBNET=<subnet>   \
+GCS_STAGING_LOCATION=<gcs-staging-bucket-folder> \
+HISTORY_SERVER_CLUSTER=<history-server> \
+bin/start.sh \
+-- --template KAFKATOGCS \
+--templateProperty project.id=<gcp-project-id> \
+--templateProperty kafka.gcs.output.location=<gcs path> \
+--templateProperty kafka.gcs.bootstrap.servers=<kafka broker list> \
+--templateProperty kafka.gcs.topic=<kafka topic name> \
+```
+
+
+### Configurable Parameters
+Update Following properties in  [template.properties](../../../../../../../resources/template.properties) file:
+```
+kafka.gcs.output.location=<gcs location>;
+kafka.gcs.output.format=<gcs output format>;
+kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
+kafka.gcs.topic=<kafka topic>;
+
+#Offset to start reading from. Values can be '**earliest**' ,'lateßst', '<topic_name>:{<partition>:<offeset>}' ...
+kafka.gcs.starting.offset=<starting offset value>
+
+#Await time in milliseconds before terminating stream read
+kafka.gcs.await.termination.timeout=<stream await termination timeout>
+```

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
@@ -12,8 +12,8 @@ bin/start.sh \
 -- --template KAFKATOGCS \
 --templateProperty project.id=<gcp-project-id> \
 --templateProperty kafka.gcs.output.location=<gcs path> \
---templateProperty kafka.gcs.bootstrap.servers=<kafka broker list> \
---templateProperty kafka.gcs.topic=<kafka topic name> \
+--templateProperty kafka.bootstrap.servers=<kafka broker list> \
+--templateProperty kafka.topic=<kafka topic name> \
 ```
 
 
@@ -22,11 +22,17 @@ Update Following properties in  [template.properties](../../../../../../../resou
 ```
 kafka.gcs.output.location=<gcs location>;
 kafka.gcs.output.format=<gcs output format>;
-kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
-kafka.gcs.topic=<kafka topic>;
+kafka.bootstrap.servers=<kafka bootstrap server>;
+kafka.topic=<kafka topic>;
+
+#Message format can be "json" or "bytes" for bytestring
+kafka.message.format=<kafka message format>
+
+#Specifying schema is mandatory for JSON message format
+kafka.schema.url=<gcs url for schema file>
 
 #Offset to start reading from. Values can be '**earliest**' ,'latest', '<topic_name>:{<partition>:<offset>}' ...
-kafka.gcs.starting.offset=<starting offset value>
+kafka.starting.offset=<starting offset value>
 
 #Await time in milliseconds before terminating stream read
 kafka.gcs.await.termination.timeout=<stream await termination timeout>

--- a/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
+++ b/src/main/java/com/google/cloud/dataproc/templates/kafka/README.md
@@ -25,9 +25,12 @@ kafka.gcs.output.format=<gcs output format>;
 kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
 kafka.gcs.topic=<kafka topic>;
 
-#Offset to start reading from. Values can be '**earliest**' ,'lateßst', '<topic_name>:{<partition>:<offeset>}' ...
+#Offset to start reading from. Values can be '**earliest**' ,'latest', '<topic_name>:{<partition>:<offset>}' ...
 kafka.gcs.starting.offset=<starting offset value>
 
 #Await time in milliseconds before terminating stream read
 kafka.gcs.await.termination.timeout=<stream await termination timeout>
+
+#Ouptut mode for writing data. Values can be 'append', 'complete', 'update'
+kafka.gcs.output.mode=<kafka output mode> 
 ```

--- a/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
@@ -26,6 +26,7 @@ import com.google.cloud.dataproc.templates.hive.HiveToBigQuery;
 import com.google.cloud.dataproc.templates.hive.HiveToGCS;
 import com.google.cloud.dataproc.templates.jdbc.JDBCToBigQuery;
 import com.google.cloud.dataproc.templates.jdbc.JDBCToGCS;
+import com.google.cloud.dataproc.templates.kafka.KafkaToGCS;
 import com.google.cloud.dataproc.templates.pubsub.PubSubToBQ;
 import com.google.cloud.dataproc.templates.s3.S3ToBigQuery;
 import com.google.cloud.dataproc.templates.util.PropertyUtil;
@@ -63,6 +64,7 @@ public class DataProcTemplate {
           .put(TemplateName.JDBCTOGCS, (args) -> new JDBCToGCS())
           .put(TemplateName.GCSTOSPANNER, GCSToSpanner::of)
           .put(TemplateName.GENERAL, GeneralTemplate::of)
+          .put(TemplateName.KAFKATOGCS, (args) -> new KafkaToGCS())
           .build();
   private static final String TEMPLATE_NAME_LONG_OPT = "template";
   private static final String TEMPLATE_PROPERTY_LONG_OPT = "templateProperty";

--- a/src/main/java/com/google/cloud/dataproc/templates/util/ReadSchemaUtil.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/util/ReadSchemaUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.util;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReadSchemaUtil {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReadSchemaUtil.class);
+
+  public static StructType readSchema(String schemaUrl) {
+
+    StructType schema = null;
+
+    String[] split_url = schemaUrl.split("/", 2);
+    String bucket = split_url[0];
+    String objectUrl = split_url[1];
+
+    Storage storage = StorageOptions.getDefaultInstance().getService();
+
+
+    try {
+      Blob blob = storage.get(bucket, objectUrl);
+      String schemaSource = new String(blob.getContent());
+      schema = (StructType) DataType.fromJson(schemaSource);
+    }
+    catch (Throwable th){
+      LOGGER.error("Exception occured while reading the schema URL",th);
+    }
+
+    return schema;
+  }
+}

--- a/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -198,13 +198,18 @@ public interface TemplateConstants {
 
   String BQ_GCS_OUTPUT_LOCATION = "bigquery.gcs.output.location";
 
+  /** Common properties for all Kafka Based Templates * */
+  String KAFKA_MESSAGE_FORMAT = "kafka.message.format";
+
+  String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
+  String KAFKA_TOPIC = "kafka.topic";
+  String KAFKA_STARTING_OFFSET = "kafka.starting.offset";
+  String KAFKA_SCHEMA_URL = "kafka.schema.url";
+
   /** Kafka To GCS properties */
   String KAFKA_GCS_OUTPUT_LOCATION = "kafka.gcs.output.location";
 
   String KAFKA_GCS_OUTPUT_FORMAT = "kafka.gcs.output.format";
-  String KAFKA_GCS_BOOTSTRAP_SERVERS = "kafka.gcs.bootstrap.servers";
-  String KAFKA_GCS_TOPIC = "kafka.gcs.topic";
-  String KAFKA_GCS_STARTING_OFFSET = "kafka.gcs.starting.offset";
   String KAFKA_GCS_OUTPUT_MODE = "kafka.gcs.output.mode";
   String KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT = "kafka.gcs.await.termination.timeout";
 }

--- a/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -197,4 +197,18 @@ public interface TemplateConstants {
   String BQ_GCS_OUTPUT_FORMAT = "bigquery.gcs.output.format";
 
   String BQ_GCS_OUTPUT_LOCATION = "bigquery.gcs.output.location";
+
+  /** Kafka To GCS properties */
+  String KAFKA_GCS_OUTPUT_LOCATION = "kafka.gcs.output.location";
+
+  String KAFKA_GCS_OUTPUT_FORMAT = "kafka.gcs.output.format";
+  String KAFKA_GCS_OUTPUT_FORMAT_DEFAULT = "csv";
+  String KAFKA_GCS_BOOTSTRAP_SERVERS = "kafka.gcs.bootstrap.servers";
+  String KAFKA_GCS_TOPIC = "kafka.gcs.topic";
+  String KAFKA_GCS_STARTING_OFFSET = "kafka.gcs.starting.offset";
+  String KAFKA_GCS_STARTING_OFFSET_DEFAULT = "latest";
+  String KAFKA_GCS_OUTPUT_MODE = "kafka.gcs.output.mode";
+  String KAFKA_GCS_OUTPUT_MODE_DEFAULT = "append";
+  String KAFKA_GCS_AWAIT_TIMEOUT = "kafka.gcs.termination.timeout";
+  String KAFKA_GCS_AWAIT_TIMEOUT_DEFAULT = "300000";
 }

--- a/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -200,14 +200,11 @@ public interface TemplateConstants {
 
   /** Kafka To GCS properties */
   String KAFKA_GCS_OUTPUT_LOCATION = "kafka.gcs.output.location";
+
   String KAFKA_GCS_OUTPUT_FORMAT = "kafka.gcs.output.format";
-  String KAFKA_GCS_OUTPUT_FORMAT_DEFAULT = "csv";
   String KAFKA_GCS_BOOTSTRAP_SERVERS = "kafka.gcs.bootstrap.servers";
   String KAFKA_GCS_TOPIC = "kafka.gcs.topic";
   String KAFKA_GCS_STARTING_OFFSET = "kafka.gcs.starting.offset";
-  String KAFKA_GCS_STARTING_OFFSET_DEFAULT = "latest";
   String KAFKA_GCS_OUTPUT_MODE = "kafka.gcs.output.mode";
-  String KAFKA_GCS_OUTPUT_MODE_DEFAULT = "append";
   String KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT = "kafka.gcs.await.termination.timeout";
-  String KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT_DEFAULT = "300000";
 }

--- a/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -200,7 +200,6 @@ public interface TemplateConstants {
 
   /** Kafka To GCS properties */
   String KAFKA_GCS_OUTPUT_LOCATION = "kafka.gcs.output.location";
-
   String KAFKA_GCS_OUTPUT_FORMAT = "kafka.gcs.output.format";
   String KAFKA_GCS_OUTPUT_FORMAT_DEFAULT = "csv";
   String KAFKA_GCS_BOOTSTRAP_SERVERS = "kafka.gcs.bootstrap.servers";
@@ -209,6 +208,6 @@ public interface TemplateConstants {
   String KAFKA_GCS_STARTING_OFFSET_DEFAULT = "latest";
   String KAFKA_GCS_OUTPUT_MODE = "kafka.gcs.output.mode";
   String KAFKA_GCS_OUTPUT_MODE_DEFAULT = "append";
-  String KAFKA_GCS_AWAIT_TIMEOUT = "kafka.gcs.termination.timeout";
-  String KAFKA_GCS_AWAIT_TIMEOUT_DEFAULT = "300000";
+  String KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT = "kafka.gcs.await.termination.timeout";
+  String KAFKA_GCS_AWAIT_TERMINATION_TIMEOUT_DEFAULT = "300000";
 }

--- a/src/main/resources/template.properties
+++ b/src/main/resources/template.properties
@@ -144,10 +144,11 @@ gcs.spanner.output.saveMode=<Append|Overwrite|ErrorIfExists|Ignore>
 gcs.spanner.output.primaryKey=<column[(,column)*] - primary key columns needed when creating the table>
 
 
-# Kafka To GCS
+#Kafka To GCS
 #kafka.gcs.output.location=<gcs location>;
-#kafka.gcs.output.format=<gcs output format>;
+kafka.gcs.output.format=csv
 #kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
 #kafka.gcs.topic=<kafka topic>;
-#kafka.gcs.starting.offset=<partition and offset value>
-#kafka.gcs.await.termination.timeout=<stream await termination timeout>
+kafka.gcs.starting.offset=earliest
+kafka.gcs.output.mode=append
+kafka.gcs.await.termination.timeout=300000

--- a/src/main/resources/template.properties
+++ b/src/main/resources/template.properties
@@ -146,6 +146,8 @@ gcs.spanner.output.primaryKey=<column[(,column)*] - primary key columns needed w
 
 # Kafka To GCS
 #kafka.gcs.output.location=<gcs location>;
-#kafka.gcs.output.format=;
+#kafka.gcs.output.format=<gcs output format>;
 #kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
 #kafka.gcs.topic=<kafka topic>;
+#kafka.gcs.starting.offset=<partition and offset value>
+#kafka.gcs.await.termination.timeout=<stream await termination timeout>

--- a/src/main/resources/template.properties
+++ b/src/main/resources/template.properties
@@ -142,3 +142,10 @@ gcs.spanner.output.database=<spanner database id>
 gcs.spanner.output.table=<spanner table id>
 gcs.spanner.output.saveMode=<Append|Overwrite|ErrorIfExists|Ignore>
 gcs.spanner.output.primaryKey=<column[(,column)*] - primary key columns needed when creating the table>
+
+
+# Kafka To GCS
+#kafka.gcs.output.location=<gcs location>;
+#kafka.gcs.output.format=;
+#kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
+#kafka.gcs.topic=<kafka topic>;

--- a/src/main/resources/template.properties
+++ b/src/main/resources/template.properties
@@ -146,9 +146,9 @@ gcs.spanner.output.primaryKey=<column[(,column)*] - primary key columns needed w
 
 #Kafka To GCS
 #kafka.gcs.output.location=<gcs location>;
-kafka.gcs.output.format=csv
+kafka.gcs.output.format=parquet
 #kafka.gcs.bootstrap.servers=<kafka bootstrap server>;
 #kafka.gcs.topic=<kafka topic>;
-kafka.gcs.starting.offset=earliest
+kafka.starting.offset=earliest
 kafka.gcs.output.mode=append
 kafka.gcs.await.termination.timeout=300000

--- a/src/test/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCSTest.java
+++ b/src/test/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCSTest.java
@@ -35,8 +35,8 @@ public class KafkaToGCSTest {
   void setup() {
     PropertyUtil.getProperties().setProperty(KAFKA_GCS_OUTPUT_LOCATION, "some value");
     PropertyUtil.getProperties().setProperty(KAFKA_GCS_OUTPUT_FORMAT, "some value");
-    PropertyUtil.getProperties().setProperty(KAFKA_GCS_BOOTSTRAP_SERVERS, "value");
-    PropertyUtil.getProperties().setProperty(KAFKA_GCS_TOPIC, "value");
+    PropertyUtil.getProperties().setProperty(KAFKA_BOOTSTRAP_SERVERS, "value");
+    PropertyUtil.getProperties().setProperty(KAFKA_TOPIC, "value");
   }
 
   @ParameterizedTest
@@ -65,9 +65,6 @@ public class KafkaToGCSTest {
 
   static Stream<String> propertyKeys() {
     return Stream.of(
-        KAFKA_GCS_OUTPUT_LOCATION,
-        KAFKA_GCS_OUTPUT_FORMAT,
-        KAFKA_GCS_BOOTSTRAP_SERVERS,
-        KAFKA_GCS_TOPIC);
+        KAFKA_GCS_OUTPUT_LOCATION, KAFKA_GCS_OUTPUT_FORMAT, KAFKA_BOOTSTRAP_SERVERS, KAFKA_TOPIC);
   }
 }

--- a/src/test/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCSTest.java
+++ b/src/test/java/com/google/cloud/dataproc/templates/kafka/KafkaToGCSTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.kafka;
+
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.cloud.dataproc.templates.util.PropertyUtil;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaToGCSTest {
+
+  private KafkaToGCS kafkaToGCSTest;
+  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaToGCSTest.class);
+
+  @BeforeEach
+  void setup() {
+    PropertyUtil.getProperties().setProperty(KAFKA_GCS_OUTPUT_LOCATION, "some value");
+    PropertyUtil.getProperties().setProperty(KAFKA_GCS_OUTPUT_FORMAT, "some value");
+    PropertyUtil.getProperties().setProperty(KAFKA_GCS_BOOTSTRAP_SERVERS, "value");
+    PropertyUtil.getProperties().setProperty(KAFKA_GCS_TOPIC, "value");
+  }
+
+  @ParameterizedTest
+  @MethodSource("propertyKeys")
+  void runTemplateWithValidParameters(String propKey) {
+    PropertyUtil.getProperties().setProperty(propKey, "some value");
+
+    kafkaToGCSTest = new KafkaToGCS();
+    assertDoesNotThrow(kafkaToGCSTest::runTemplate);
+  }
+
+  @ParameterizedTest
+  @MethodSource("propertyKeys")
+  void runTemplateWithInvalidParameters(String propKey) {
+    PropertyUtil.getProperties().setProperty(propKey, "");
+    kafkaToGCSTest = new KafkaToGCS();
+
+    Exception exception =
+        assertThrows(IllegalArgumentException.class, () -> kafkaToGCSTest.runTemplate());
+    assertEquals(
+        "Required parameters for KafkaToGCS not passed. "
+            + "Set mandatory parameter for KafkaToGCS template "
+            + "in resources/conf/template.properties file.",
+        exception.getMessage());
+  }
+
+  static Stream<String> propertyKeys() {
+    return Stream.of(
+        KAFKA_GCS_OUTPUT_LOCATION,
+        KAFKA_GCS_OUTPUT_FORMAT,
+        KAFKA_GCS_BOOTSTRAP_SERVERS,
+        KAFKA_GCS_TOPIC);
+  }
+}


### PR DESCRIPTION
New Template for KafkaToGCS. 
Also include reusable KafkaReader that can be leveraged by all future KafkaTemplates. Currently supports "bytestring" and JSON message formats. 