### PR TITLE
Publishing HiveToBigquery Medium blogpost

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please refer to the [Dataproc Templates (Python - PySpark) README](/python/READM
 * [GCSToBigQuery](/python/dataproc_templates/gcs/README.md) (blogpost [link](https://medium.com/@ppaglilla/getting-started-with-dataproc-serverless-pyspark-templates-e32278a6a06e))
 * [GCSToBigTable](/python/dataproc_templates/gcs/README.md)
 * [GCSToJDBC](/python/dataproc_templates/gcs/README.md)
-* [HiveToBigQuery](/python/dataproc_templates/hive/README.md)
+* [HiveToBigQuery](/python/dataproc_templates/hive/README.md) (blogpost [link](https://medium.com/google-cloud/processing-data-from-hive-to-bigquery-using-pyspark-and-dataproc-serverless-217c7cb9e4f8))
 * [HiveToGCS](/python/dataproc_templates/hive/README.md)
 * [HbaseToGCS](/python/dataproc_templates/hbase/README.md)
 * [JDBCToJDBC](/python/dataproc_templates/jdbc/README.md)

--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@
 * [GCSToBigQuery](/python/dataproc_templates/gcs/README.md) (blogpost [link](https://medium.com/@ppaglilla/getting-started-with-dataproc-serverless-pyspark-templates-e32278a6a06e))
 * [GCSToBigTable](/python/dataproc_templates/gcs/README.md)
 * [GCSToJDBC](/python/dataproc_templates/gcs/README.md)
-* [HiveToBigQuery](/python/dataproc_templates/hive/README.md)
+* [HiveToBigQuery](/python/dataproc_templates/hive/README.md) (blogpost [link](https://medium.com/google-cloud/processing-data-from-hive-to-bigquery-using-pyspark-and-dataproc-serverless-217c7cb9e4f8))
 * [HiveToGCS](/python/dataproc_templates/hive/README.md)
 * [HbaseToGCS](/python/dataproc_templates/hbase/README.md)
 * [JDBCToJDBC](/python/dataproc_templates/jdbc/README.md)


### PR DESCRIPTION
This pull request adds the link to the blog post: Processing data from Hive to BigQuery using PySpark and Dataproc Serverless

Closes #129