### PR TITLE
fixing bug in filter

### DIFF
--- a/java/src/main/java/com/google/cloud/dataproc/templates/bigquery/BigQueryToGCS.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/bigquery/BigQueryToGCS.java
@@ -26,6 +26,7 @@ import static com.google.cloud.dataproc.templates.util.TemplateConstants.GCS_BQ_
 import static com.google.cloud.dataproc.templates.util.TemplateConstants.GCS_BQ_CSV_FORMAT;
 import static com.google.cloud.dataproc.templates.util.TemplateConstants.GCS_BQ_CSV_HEADER;
 import static com.google.cloud.dataproc.templates.util.TemplateConstants.GCS_BQ_CSV_INFOR_SCHEMA;
+import static com.google.cloud.dataproc.templates.util.TemplateConstants.SPARK_READ_FORMAT_BIGQUERY;
 
 import com.google.cloud.dataproc.templates.BaseTemplate;
 import java.util.Objects;
@@ -70,7 +71,7 @@ public class BigQueryToGCS implements BaseTemplate {
     SparkSession spark = null;
     try {
       spark = SparkSession.builder().appName("BigQuery to GCS").getOrCreate();
-      Dataset<Row> inputData = spark.read().format("bigquery").load(inputTableName);
+      Dataset<Row> inputData = spark.read().format(SPARK_READ_FORMAT_BIGQUERY).load(inputTableName);
       DataFrameWriter<Row> writer = inputData.write();
       switch (outputFileFormat) {
         case BQ_GCS_OUTPUT_FORMAT_CSV:

--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
@@ -73,7 +73,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
   public static String SPARK_SQL_COMPARE_COLS = "t1.%s=t2.%s";
   public static String SPARK_SQL_AND = " AND ";
   public static String SPARK_SQL_GET_NEW_PATHS =
-      "SELECT %s FROM %s t1 LEFT JOIN %s t2 ON %s WHERE t2.id is null";
+      "SELECT %s FROM %s t1 LEFT JOIN %s t2 ON %s WHERE t2.%s is null";
   public static String SPARK_SQL_OUTPUT_TABLE_TEMP_VIEW_NAME = "__table__";
   public static String GCS_PATH_PREFIX = "gs://";
   public static String EMPTY_STRING = "";
@@ -288,7 +288,8 @@ public class DataplexGCStoBQ implements BaseTemplate {
                 SPARK_SQL_GCS_LOCATION_PATH_COL_NAME,
                 SPARK_SQL_DATAPLEX_PARTITION_KEYS_TEMP_VIEW_NAME,
                 SPARK_SQL_BQ_PARTITION_KEYS_TEMP_VIEW,
-                joinClause));
+                joinClause,
+                partitionKeysList.get(0)));
     return newPartitionsDS;
   }
 

--- a/java/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/main/DataProcTemplate.java
@@ -108,7 +108,7 @@ public class DataProcTemplate {
     CommandLineParser parser = new DefaultParser();
     LOGGER.info("Parsing arguments {}", (Object) args);
     try {
-      return parser.parse(options, args, false);
+      return parser.parse(options, args, true);
     } catch (ParseException e) {
       throw new IllegalArgumentException(e.getMessage(), e);
     }

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -219,7 +219,7 @@ public interface TemplateConstants {
   String SPARK_CONF_NAME_VIEWS_ENABLED = "viewsEnabled";
   String SPARK_CONF_NAME_MATERIALIZATION_PROJECT = "materializationProject";
   String SPARK_CONF_NAME_MATERIALIZATION_DATASET = "materializationDataset";
-  String SPARK_READ_FORMAT_BIGQUERY = "bigquery";
+  String SPARK_READ_FORMAT_BIGQUERY = "com.google.cloud.spark.bigquery";
   String INTERMEDIATE_FORMAT_OPTION_NAME = "intermediateFormat";
   String INTERMEDIATE_FORMAT_ORC = "orc";
 


### PR DESCRIPTION
Fixed the following issues:

1. In the Dataplex template, when comparing partitions in Dataplex vs Partitions in BigQuery the name of columns used to compare between partitions was hardcoded as `t2.id`, therefore the template would fail if the data lacked a partition key named `id`. 
2. A string literal was being used for Spark format for BigQuery in several locations across the project, changed this into a constant.  