### PR TITLE
Update MySqlToSpanner_vertex_pipeline_pyspark.ipynb

### DIFF
--- a/python/notebooks/spanner/MySqlToSpanner_vertex_pipeline_pyspark.ipynb
+++ b/python/notebooks/spanner/MySqlToSpanner_vertex_pipeline_pyspark.ipynb
@@ -219,7 +219,8 @@
     "MYSQLTABLE_LIST = [] # leave list empty for migrating complete database else provide tables as ['table1','table2']\n",
     "MYSQL_OUTPUT_GCS_LOCATION = \"<gs://bucket/[folder]>\"\n",
     "MYSQL_OUTPUT_GCS_MODE = \"<mode>\" # one of overwrite|append\n",
-    "MYSQL_OUTPUT_GCS_FORMAT = \"<format>\" # one of avro|parquet|orc"
+    "MYSQL_OUTPUT_GCS_FORMAT = \"<format>\" # one of avro|parquet|orc\n",
+    "MYSQL_NUMBER_OF_PARTITIONS = 10 # number of partitions for reading data from MySQL(Defaults to 10)"
    ]
   },
   {
@@ -379,6 +380,50 @@
   },
   {
    "cell_type": "markdown",
+   "id": "02748c28-54e9-466c-9537-c00569122a96",
+   "metadata": {},
+   "source": [
+    "#### Get Row Count of Tables and identify read partition column\n",
+    "#### This step uses PARTITION_THRESHOLD(default value is 1 million) parameter and any table having rows greater than PARTITION_THRESHOLD will be partitioned based on Primary Key\n",
+    "#### Get Primary keys for all tables to be migrated and find an integer column to partition on"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4e4f6e9-c559-48e8-95fd-d2dd3e173439",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PARTITION_THRESHOLD = 1000000\n",
+    "CHECK_PARTITION_COLUMN_LIST={}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb9f5487-bb82-4261-87ad-0a938e9df076",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with DB.connect() as conn:\n",
+    "    for table in MYSQLTABLE_LIST:\n",
+    "        results = DB.execute(\"SELECT count(1) FROM {}\".format(table)).fetchall()\n",
+    "        if results[0][0]>int(PARTITION_THRESHOLD):\n",
+    "            column_list=SPANNER_TABLE_PRIMARY_KEYS.get(table).split(\",\")\n",
+    "            for column in column_list:\n",
+    "                results_datatype = DB.execute(\"SELECT DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME   = '{0}' AND COLUMN_NAME  = '{1}'\".format(table,column)).fetchall()      \n",
+    "                if results_datatype[0][0]==\"int\":\n",
+    "                    lowerbound = DB.execute(\"SELECT min({0}) from {1}\".format(column,table)).fetchall()\n",
+    "                    upperbound = DB.execute(\"SELECT max({0}) from {1}\".format(column,table)).fetchall()\n",
+    "                    CHECK_PARTITION_COLUMN_LIST[table]=[column,lowerbound[0][0],upperbound[0][0]]\n",
+    "                \n",
+    "                \n",
+    "print(CHECK_PARTITION_COLUMN_LIST)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1fa5f841-a687-4723-a8e6-6e7e752ba36e",
    "metadata": {},
    "source": [
@@ -533,17 +578,34 @@
     "        for table in EXECUTION_LIST:\n",
     "            BATCH_ID = \"mysql2gcs-{}\".format(datetime.now().strftime(\"%s\"))\n",
     "            mysql_to_gcs_jobs.append(BATCH_ID)\n",
-    "            TEMPLATE_SPARK_ARGS = [\n",
-    "            \"--template=JDBCTOGCS\",\n",
-    "            \"--templateProperty\", \"project.id={}\".format(PROJECT),\n",
-    "            \"--templateProperty\", \"jdbctogcs.jdbc.url={}\".format(JDBC_URL),\n",
-    "            \"--templateProperty\", \"jdbctogcs.jdbc.driver.class.name={}\".format(JDBC_DRIVER),\n",
-    "            \"--templateProperty\",\"jdbctogcs.output.location={}/{}\".format(MYSQL_OUTPUT_GCS_LOCATION,table),\n",
-    "            \"--templateProperty\", \"jdbctogcs.output.format={}\".format(MYSQL_OUTPUT_GCS_FORMAT),\n",
-    "            \"--templateProperty\", \"jdbctogcs.write.mode={}\".format(MYSQL_OUTPUT_GCS_MODE),\n",
-    "            \"--templateProperty\", \"jdbctogcs.sql=select * from {}\".format(table),\n",
-    "            ]\n",
-    "\n",
+    "            if table in CHECK_PARTITION_COLUMN_LIST.keys():\n",
+    "                TEMPLATE_SPARK_ARGS = [\n",
+    "                \"--template=JDBCTOGCS\",\n",
+    "                \"--templateProperty\", \"project.id={}\".format(PROJECT),\n",
+    "                \"--templateProperty\", \"jdbctogcs.jdbc.url={}\".format(JDBC_URL),\n",
+    "                \"--templateProperty\", \"jdbctogcs.jdbc.driver.class.name={}\".format(JDBC_DRIVER),\n",
+    "                \"--templateProperty\",\"jdbctogcs.output.location={}/{}\".format(MYSQL_OUTPUT_GCS_LOCATION,table),\n",
+    "                \"--templateProperty\", \"jdbctogcs.output.format={}\".format(MYSQL_OUTPUT_GCS_FORMAT),\n",
+    "                \"--templateProperty\", \"jdbctogcs.write.mode={}\".format(MYSQL_OUTPUT_GCS_MODE),\n",
+    "                \"--templateProperty\", \"jdbctogcs.sql=select * from {}\".format(table),\n",
+    "                \"--templateProperty jdbctogcs.sql.partitionColumn={}\".format(CHECK_PARTITION_COLUMN_LIST[table][0]),\n",
+    "                \"--templateProperty jdbctogcs.sql.lowerBound={}\".format(CHECK_PARTITION_COLUMN_LIST[table][1]),\n",
+    "                \"--templateProperty jdbctogcs.sql.upperBound={}\".format(CHECK_PARTITION_COLUMN_LIST[table][2]),\n",
+    "                \"--templateProperty jdbctogcs.sql.numPartitions={}\".format(MYSQL_NUMBER_OF_PARTITIONS),\n",
+    "                \"--templateProperty jdbctogcs.output.partition.col={}\".format(CHECK_PARTITION_COLUMN_LIST[table][0]),\n",
+    "                ]\n",
+    "            else:\n",
+    "                TEMPLATE_SPARK_ARGS = [\n",
+    "                \"--template=JDBCTOGCS\",\n",
+    "                \"--templateProperty\", \"project.id={}\".format(PROJECT),\n",
+    "                \"--templateProperty\", \"jdbctogcs.jdbc.url={}\".format(JDBC_URL),\n",
+    "                \"--templateProperty\", \"jdbctogcs.jdbc.driver.class.name={}\".format(JDBC_DRIVER),\n",
+    "                \"--templateProperty\",\"jdbctogcs.output.location={}/{}\".format(MYSQL_OUTPUT_GCS_LOCATION,table),\n",
+    "                \"--templateProperty\", \"jdbctogcs.output.format={}\".format(MYSQL_OUTPUT_GCS_FORMAT),\n",
+    "                \"--templateProperty\", \"jdbctogcs.write.mode={}\".format(MYSQL_OUTPUT_GCS_MODE),\n",
+    "                \"--templateProperty\", \"jdbctogcs.sql=select * from {}\".format(table),\n",
+    "                ]\n",
+    "    \n",
     "            _ = DataprocSparkBatchOp(\n",
     "                project=PROJECT_ID,\n",
     "                location=LOCATION,\n",


### PR DESCRIPTION
Issue [#270]

Addressed the below two points:
- identify partitioned read properties.
- Should generate logic for partitioned read, such that each partition read is <2 GB in size.

The following ask requires a new issue:
- validate if all parameters with valid values are provided

Tested with [TPCDS dataset](https://relational.fit.cvut.cz/dataset/TPCDS)
Results attached here: [MySqlToSpanner_vertex_pipeline_pyspark.pdf](https://github.com/GoogleCloudPlatform/dataproc-templates/files/9686853/MySqlToSpanner_vertex_pipeline_pyspark.pdf)

A few tables failed with the following error:
<img width="1455" alt="Screen Shot 2022-09-30 at 11 58 03 PM" src="https://user-images.githubusercontent.com/105050600/193333916-24c23b3f-4650-464f-9f40-83ec85a09c6b.png">

