### PR TITLE
Dataplex target entity

### DIFF
--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
@@ -425,22 +425,17 @@ public class DataplexGCStoBQ implements BaseTemplate {
   }
 
   public void checkTarget() throws IOException {
-    System.out.println("========================================================");
     if (!StringUtils.isAllBlank(this.targetEntity)) {
-      System.out.println("target entity def");
       DataplexEntityUtil dataplexTargetEntityUtil = new DataplexEntityUtil(this.targetEntity);
       this.targetTable = dataplexTargetEntityUtil.getTableFullName();
-      System.out.println(this.targetTable);
       this.targetDataset = this.targetTable.split("\\.")[1];
     } else {
       if (!StringUtils.isAllBlank(this.targetAsset)) {
-        System.out.println("target asset def");
         DataplexAssetUtil dataplexAssetUtil = new DataplexAssetUtil(this.targetAsset);
         this.projectId = dataplexAssetUtil.getProjectId();
         this.targetDataset = dataplexAssetUtil.getDatasetName();
       }
       if (this.targetTableName == null) {
-        System.out.println("target table def");
         this.targetTableName =
             this.sourceEntity
                 .split(FORWARD_SLASH)[this.sourceEntity.split(FORWARD_SLASH).length - 1];
@@ -448,30 +443,10 @@ public class DataplexGCStoBQ implements BaseTemplate {
       this.targetTable =
           String.format(BQ_TABLE_NAME_FORMAT, projectId, targetDataset, targetTableName);
     }
-    System.out.println(this.targetTable);
-    System.out.println("========================================================");
   }
 
   public void runTemplate() {
-    System.out.println("run");
     try {
-      //      String entityName =
-      //
-      // "projects/yadavaja-sandbox/locations/us-central1/lakes/whaite-gcs2bq-test/zones/whaite-zone-4/entities/trips_parquet_1";
-      //      DataplexEntityUtil dataplexEntityUtil = new DataplexEntityUtil(entityName);
-      //      String tableName = dataplexEntityUtil.getTableFullName();
-      //      System.out.println("============================================");
-      //      System.out.println(tableName);
-      //      System.out.println("============================================");
-      //
-      //      String assetName =
-      //
-      // "projects/yadavaja-sandbox/locations/us-central1/lakes/whaite-gcs2bq-test/zones/whaite-zone-4/assets/whaite-dataplex-target-asset";
-      //      DataplexAssetUtil dataplexAssetUtil = new DataplexAssetUtil(assetName);
-      //      String datasetName = dataplexAssetUtil.getDatasetName();
-      //      System.out.println("============================================");
-      //      System.out.println(datasetName);
-      //      System.out.println("============================================");
       this.spark = SparkSession.builder().appName("Dataplex GCS to BQ").getOrCreate();
       this.sqlContext = new SQLContext(spark);
       checkInput();

--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/DataplexGCStoBQ.java
@@ -20,8 +20,8 @@ import static com.google.cloud.dataproc.templates.util.TemplateConstants.*;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.dataproc.templates.BaseTemplate;
 import com.google.cloud.dataproc.templates.gcs.GCStoBigquery;
-import com.google.cloud.dataproc.templates.util.DataplexUtil;
-import com.google.cloud.dataproc.templates.util.DataplexUtil.DataplexUtilNoPartitionError;
+import com.google.cloud.dataproc.templates.util.Dataplex.DataplexAssetUtil;
+import com.google.cloud.dataproc.templates.util.Dataplex.DataplexEntityUtil;
 import com.google.cloud.dataproc.templates.util.DataprocTemplateException;
 import com.google.cloud.spark.bigquery.repackaged.com.google.cloud.bigquery.connector.common.BigQueryConnectorException;
 import com.google.cloud.storage.Blob;
@@ -33,6 +33,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.cli.*;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.spark.sql.DataFrameReader;
 import org.apache.spark.sql.DataFrameWriter;
 import org.apache.spark.sql.Dataset;
@@ -58,7 +59,6 @@ public class DataplexGCStoBQ implements BaseTemplate {
   public static String PARTITION_TYPE_OPTION = "partitionType";
   public static String TARGET_TABLE_NAME_OPTION = "targetTableName";
   public static String INCREMENTAL_PARTITION_COPY_NO = "no";
-  public static String BQ_TABLE_NAME_FORMAT = "%s.%s.%s";
   public static String SPARK_SQL_SELECT_STAR = "*";
   public static String SPARK_SQL_SPLIT_VALUE_AND_GET_LOCATION =
       "split(value, ',')[0] as __gcs_location_path__";
@@ -83,19 +83,21 @@ public class DataplexGCStoBQ implements BaseTemplate {
   private SparkSession spark;
   private SQLContext sqlContext;
 
-  private DataplexUtil dataplexUtil;
+  private DataplexEntityUtil sourceEntityUtil;
 
   private Dataset<Row> newDataDS;
-  private String entity;
+  private String sourceEntity;
   private String partitionField;
   private String partitionType;
 
   private String projectId;
   private String customSqlGCSPath;
-  private String entityBasePath;
+  private String sourceEntityBasePath;
   private String targetDataset;
   private String targetTableName;
   private String targetTable;
+  private String targetAsset;
+  private String targetEntity;
   private String inputFileFormat;
   private String inputCSVDelimiter;
   private String bqTempBucket;
@@ -104,18 +106,20 @@ public class DataplexGCStoBQ implements BaseTemplate {
 
   public DataplexGCStoBQ(
       String customSqlGCSPath,
-      String entity,
+      String sourceEntity,
       String partitionField,
       String partitionType,
       String targetTableName) {
     this.customSqlGCSPath = customSqlGCSPath;
-    this.entity = entity;
+    this.sourceEntity = sourceEntity;
     this.partitionField = partitionField;
     this.partitionType = partitionType;
     this.targetTableName = targetTableName;
 
     projectId = getProperties().getProperty(PROJECT_ID_PROP);
     targetDataset = getProperties().getProperty(DATAPLEX_GCS_BQ_TARGET_DATASET);
+    targetAsset = getProperties().getProperty(DATAPLEX_GCS_BQ_TARGET_ASSET);
+    targetEntity = getProperties().getProperty(DATAPLEX_GCS_BQ_TARGET_ENTITY);
     bqTempBucket = getProperties().getProperty(GCS_BQ_LD_TEMP_BUCKET_NAME);
     sparkSaveMode = getProperties().getProperty(DATAPLEX_GCS_BQ_SAVE_MODE);
     incrementalParittionCopy =
@@ -128,12 +132,12 @@ public class DataplexGCStoBQ implements BaseTemplate {
   public static DataplexGCStoBQ of(String... args) {
     CommandLine cmd = parseArguments(args);
     String customSqlGCSPath = cmd.getOptionValue(CUSTOM_SQL_GCS_PATH_OPTION);
-    String entity = cmd.getOptionValue(ENTITY_OPTION);
+    String sourceEntity = cmd.getOptionValue(ENTITY_OPTION);
     String partitionField = cmd.getOptionValue(PARTITION_FIELD_OPTION);
     String partitionType = cmd.getOptionValue(PARTITION_TYPE_OPTION);
     String targetTableName = cmd.getOptionValue("targetTableName");
     return new DataplexGCStoBQ(
-        customSqlGCSPath, entity, partitionField, partitionType, targetTableName);
+        customSqlGCSPath, sourceEntity, partitionField, partitionType, targetTableName);
   }
 
   /**
@@ -142,8 +146,8 @@ public class DataplexGCStoBQ implements BaseTemplate {
    * @throws Exception if values no value is passed for --dataplexEntity
    */
   private void checkInput() {
-    if (entity != null) {
-      this.entity = entity;
+    if (sourceEntity != null) {
+      this.sourceEntity = sourceEntity;
     } else {
       throw new DataprocTemplateException(String.format("Please specify %s", ENTITY_OPTION));
     }
@@ -212,15 +216,14 @@ public class DataplexGCStoBQ implements BaseTemplate {
    * Execute request on Google API to fetch schema of a Dataplex entity and parses out a list of
    * partition Keys
    *
-   * @param entity name
    * @return list with partition keys of the entity, return null if Dataplex entity has no
    *     partitions
    * @throws IOException when request on Dataplex API fails
    */
-  private List<String> getPartitionKeyList(String entity) throws IOException {
+  private List<String> getPartitionKeyList() throws IOException {
     try {
-      return this.dataplexUtil.getPartitionKeyList();
-    } catch (DataplexUtilNoPartitionError e) {
+      return this.sourceEntityUtil.getPartitionKeyList();
+    } catch (DataplexEntityUtil.DataplexEntityUtilNoPartitionError e) {
       LOGGER.info("Source data has no partitions, performing a full load");
       return null;
     }
@@ -324,7 +327,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
         sqlContext
             .read()
             .format(inputFileFormat)
-            .option(DATAPLEX_GCS_BQ_BASE_PATH_PROP_NAME, entityBasePath);
+            .option(DATAPLEX_GCS_BQ_BASE_PATH_PROP_NAME, sourceEntityBasePath);
 
     if (this.inputFileFormat.equals(GCS_BQ_CSV_FORMAT)) {
       DfReader.option(GCS_BQ_CSV_HEADER, true)
@@ -421,38 +424,80 @@ public class DataplexGCStoBQ implements BaseTemplate {
     }
   }
 
+  public void checkTarget() throws IOException {
+    System.out.println("========================================================");
+    if (!StringUtils.isAllBlank(this.targetEntity)) {
+      System.out.println("target entity def");
+      DataplexEntityUtil dataplexTargetEntityUtil = new DataplexEntityUtil(this.targetEntity);
+      this.targetTable = dataplexTargetEntityUtil.getTableFullName();
+      System.out.println(this.targetTable);
+      this.targetDataset = this.targetTable.split("\\.")[1];
+    } else {
+      if (!StringUtils.isAllBlank(this.targetAsset)) {
+        System.out.println("target asset def");
+        DataplexAssetUtil dataplexAssetUtil = new DataplexAssetUtil(this.targetAsset);
+        this.projectId = dataplexAssetUtil.getProjectId();
+        this.targetDataset = dataplexAssetUtil.getDatasetName();
+      }
+      if (this.targetTableName == null) {
+        System.out.println("target table def");
+        this.targetTableName =
+            this.sourceEntity
+                .split(FORWARD_SLASH)[this.sourceEntity.split(FORWARD_SLASH).length - 1];
+      }
+      this.targetTable =
+          String.format(BQ_TABLE_NAME_FORMAT, projectId, targetDataset, targetTableName);
+    }
+    System.out.println(this.targetTable);
+    System.out.println("========================================================");
+  }
+
   public void runTemplate() {
+    System.out.println("run");
     try {
+      //      String entityName =
+      //
+      // "projects/yadavaja-sandbox/locations/us-central1/lakes/whaite-gcs2bq-test/zones/whaite-zone-4/entities/trips_parquet_1";
+      //      DataplexEntityUtil dataplexEntityUtil = new DataplexEntityUtil(entityName);
+      //      String tableName = dataplexEntityUtil.getTableFullName();
+      //      System.out.println("============================================");
+      //      System.out.println(tableName);
+      //      System.out.println("============================================");
+      //
+      //      String assetName =
+      //
+      // "projects/yadavaja-sandbox/locations/us-central1/lakes/whaite-gcs2bq-test/zones/whaite-zone-4/assets/whaite-dataplex-target-asset";
+      //      DataplexAssetUtil dataplexAssetUtil = new DataplexAssetUtil(assetName);
+      //      String datasetName = dataplexAssetUtil.getDatasetName();
+      //      System.out.println("============================================");
+      //      System.out.println(datasetName);
+      //      System.out.println("============================================");
       this.spark = SparkSession.builder().appName("Dataplex GCS to BQ").getOrCreate();
       this.sqlContext = new SQLContext(spark);
       checkInput();
 
-      this.dataplexUtil = new DataplexUtil(entity);
-      this.entityBasePath = dataplexUtil.getBasePathEntityData();
-      this.inputFileFormat = dataplexUtil.getInputFileFormat();
+      this.sourceEntityUtil = new DataplexEntityUtil(this.sourceEntity);
+      this.sourceEntityBasePath = sourceEntityUtil.getBasePathEntityData();
+      this.inputFileFormat = sourceEntityUtil.getInputFileFormat();
 
       // checking for CSV delimiter when applicable
       if (this.inputFileFormat.equals(GCS_BQ_CSV_FORMAT)) {
-        this.inputCSVDelimiter = dataplexUtil.getInputCSVDelimiter();
+        this.inputCSVDelimiter = sourceEntityUtil.getInputCSVDelimiter();
       }
 
-      // checking for user providede target table name
-      if (this.targetTableName == null) {
-        this.targetTableName = entity.split(FORWARD_SLASH)[entity.split(FORWARD_SLASH).length - 1];
-      }
-      this.targetTable =
-          String.format(BQ_TABLE_NAME_FORMAT, projectId, targetDataset, targetTableName);
+      // checking for user provided target table name
+      checkTarget();
 
       // listing source data partitions
-      List<String> partitionKeysList = getPartitionKeyList(entity);
+      List<String> partitionKeysList = getPartitionKeyList();
 
       // if source data has no partitions a full load and overwrite is performed
       if (partitionKeysList == null) {
-        newDataDS = getDataFrameReader().load(this.entityBasePath);
+        newDataDS = getDataFrameReader().load(this.sourceEntityBasePath);
         this.sparkSaveMode = SPARK_SAVE_MODE_OVERWRITE;
       } else {
         List<String> partitionsListWithLocationAndKeys =
-            dataplexUtil.getPartitionsListWithLocationAndKeys();
+            sourceEntityUtil.getPartitionsListWithLocationAndKeys();
 
         // Building dataset with all partitions keys in Dataplex Entity
         Dataset<Row> dataplexPartitionsKeysDS =
@@ -461,7 +506,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
         // Querying BQ for all partition keys currently present in target table
         Dataset<Row> bqPartitionsKeysDS = getBQTargetAvailablePartitionsDf(partitionKeysList);
 
-        // Compare dataplexPartitionsKeysDS and bqPartitionsKeysDS to indetify new
+        // Compare dataplexPartitionsKeysDS and bqPartitionsKeysDS to identify new
         // partitions
         Dataset<Row> newPartitionsPathsDS =
             getNewPartitionsPathsDS(
@@ -472,7 +517,7 @@ public class DataplexGCStoBQ implements BaseTemplate {
       }
 
       if (newDataDS != null) {
-        newDataDS = this.dataplexUtil.castDatasetToDataplexSchema(newDataDS);
+        newDataDS = this.sourceEntityUtil.castDatasetToDataplexSchema(newDataDS);
         newDataDS = applyCustomSql(newDataDS);
         writeToBQ(newDataDS);
       } else {

--- a/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/dataplex/README.md
@@ -61,6 +61,15 @@ copy new partitions only or all the partitions. If set to `no` existing
 partitions, if found will be overwritten. Can be any of the following `yes`,
 `no`. Defaults to `yes`
 
+`dataplex.gcs.bq.target.asset` specifies the Dataplex BQ Asset where the data will be written to. In other words this 
+is an alternative mechanism to specify target dataset. If `dataplex.gcs.bq.target.dataset` and 
+`dataplex.gcs.bq.target.asset` are both set, then `dataplex.gcs.bq.target.asset` will take precedence.
+
+`dataplex.gcs.bq.target.entity` specifies tha Dataplex BQ Entity where the data will be written to. In other words this 
+is an alternative mechanism to specify the target BQ table. The `dataplex.gcs.bq.target.entity` will take precedence 
+over any other property or argument specifying target output of the data.
+
+
 ### Arguments
 `--dataplexEntity` Dataplex GCS table to load in BigQuery \
 Example: `--dataplexEntityList "projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}"`

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/Dataplex/DataplexAPIUtil.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/Dataplex/DataplexAPIUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.util.Dataplex;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonObjectParser;
+import com.google.api.client.json.gson.GsonFactory;
+import com.google.auth.http.HttpCredentialsAdapter;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.spark.bigquery.repackaged.com.google.gson.JsonObject;
+import com.google.cloud.spark.bigquery.repackaged.com.google.gson.JsonParser;
+import java.io.IOException;
+
+public class DataplexAPIUtil {
+
+  /**
+   * Execute request on Google API
+   *
+   * @param url of the API method
+   * @return request response
+   * @throws IOException when request fails
+   */
+  public static JsonObject executeRequest(String url) throws IOException {
+    GoogleCredentials googleCredentials = GoogleCredentials.getApplicationDefault();
+    HttpCredentialsAdapter credentialsAdapter = new HttpCredentialsAdapter(googleCredentials);
+    HttpRequestFactory requestFactory =
+        new NetHttpTransport().createRequestFactory(credentialsAdapter);
+    HttpRequest request = requestFactory.buildGetRequest(new GenericUrl(url));
+    JsonObjectParser parser = new JsonObjectParser(GsonFactory.getDefaultInstance());
+    request.setParser(parser);
+    HttpResponse response = request.execute();
+    String resp = response.parseAsString();
+    return JsonParser.parseString(resp).getAsJsonObject();
+  }
+}

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/Dataplex/DataplexAssetUtil.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/Dataplex/DataplexAssetUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.dataproc.templates.util.Dataplex;
+
+import com.google.cloud.spark.bigquery.repackaged.com.google.gson.JsonObject;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DataplexAssetUtil {
+
+  public String assetName;
+  private JsonObject assetDetails;
+
+  private final String GET_ASSET_METHOD_URL = "https://dataplex.googleapis.com/v1/%s";
+  private final String RESOURCE_SPEC_PROP_KEY = "resourceSpec";
+  private final String NAME_PROP_KEY = "name";
+  private final String DATASET_FULLNAME_REGEX =
+      "projects\\/([a-z0-9\\-]+)\\/datasets\\/([a-zA-Z0-9_]+)";
+  private String datasetName;
+  private String projectId;
+
+  /**
+   * Constructs a new DataplexAssetUtil based on a Dataplex assetName
+   *
+   * @param assetName - the name of the Dataplex asset. Should have the format:
+   *     projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}
+   */
+  public DataplexAssetUtil(String assetName) throws IOException {
+    this.assetName = assetName;
+    this.assetDetails = getAssetDetails();
+    setDatasetFullname();
+  }
+
+  /**
+   * Execute request on Google API to fetch details of a Dataplex asset
+   *
+   * @return asset details
+   * @throws IOException when request on Dataplex API fails
+   */
+  private JsonObject getAssetDetails() throws IOException {
+    String url = String.format(GET_ASSET_METHOD_URL, this.assetName);
+    return DataplexAPIUtil.executeRequest(url);
+  }
+
+  /**
+   * Parse Dataplex asset details to extract project id and dataset name, these values will be used
+   * to ser the fields projectId and datasetName
+   *
+   * @return entity schema
+   * @throws IOException when request on Dataplex API fails
+   */
+  private void setDatasetFullname() {
+    String dataPath =
+        this.assetDetails.getAsJsonObject(RESOURCE_SPEC_PROP_KEY).get(NAME_PROP_KEY).getAsString();
+    Pattern p = Pattern.compile(DATASET_FULLNAME_REGEX);
+    Matcher m = p.matcher(dataPath);
+    m.find();
+    this.projectId = m.group(1);
+    this.datasetName = m.group(2);
+  }
+
+  public String getDatasetName() {
+    return this.datasetName;
+  }
+
+  public String getProjectId() {
+    return this.projectId;
+  }
+}

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/DataplexUtil.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/DataplexUtil.java
@@ -44,6 +44,9 @@ import org.apache.spark.sql.types.StructField;
 
 public class DataplexUtil {
 
+  public String entity;
+  private JsonObject entitySchema;
+
   private static String GET_ENTITY_METHOD_URL = "https://dataplex.googleapis.com/v1/%s?view=SCHEMA";
   private static String GET_ENTITY_PARTITIONS_METHOD_URL =
       "https://dataplex.googleapis.com/v1/%s/partitions?";
@@ -81,13 +84,24 @@ public class DataplexUtil {
   private static String DATAPLEX_DATE_DATA_TYPE_NAME = "DATE";
 
   /**
+   * Constructs a new DataplexUtils based on a Dataplex entity name
+   *
+   * @param entity - the name of the Dataplex entity. Should have the format:
+   *     projects/{project_number}/locations/{location_id}/lakes/{lake_id}/zones/{zone_id}/entities/{entity_id_1}
+   */
+  public DataplexUtil(String entity) throws IOException {
+    this.entity = entity;
+    this.entitySchema = getEntitySchema();
+  }
+
+  /**
    * Execute request on Google API
    *
    * @param url of the API method
    * @return request response
    * @throws IOException when request fails
    */
-  private static JsonObject executeRequest(String url) throws IOException {
+  private JsonObject executeRequest(String url) throws IOException {
     GoogleCredentials googleCredentials = GoogleCredentials.getApplicationDefault();
     HttpCredentialsAdapter credentialsAdapter = new HttpCredentialsAdapter(googleCredentials);
     HttpRequestFactory requestFactory =
@@ -101,61 +115,25 @@ public class DataplexUtil {
   }
 
   /**
-   * Execute request on Google API
-   *
-   * @param asset
-   * @return list of entities in the asset
-   * @throws IOException when request fails
-   */
-  public static List<String> getEntityNameListFromAsset(String asset) throws IOException {
-    List<String> entityList = new ArrayList<String>();
-    String url =
-        String.format(
-            GET_ENTITY_LIST_METHOD_URL, asset.split("/assets/")[0], asset.split("/assets/")[1]);
-    String urlWithTokenParam = url;
-    while (true) {
-      JsonObject resp = executeRequest(urlWithTokenParam);
-      Iterator entityIterator = resp.get(ASSET_ENTITIES_PROP_KEY).getAsJsonArray().iterator();
-      while (entityIterator.hasNext()) {
-        JsonObject currentEntity = (JsonObject) entityIterator.next();
-        entityList.add(currentEntity.get(ASSET_ENTITY_NAME_PROP_KEY).getAsString());
-      }
-
-      if (!resp.has(DATAPLEX_API_RESP_NEXT_PAGE_TOKEN_FIELD_NAME)) {
-        break;
-      } else {
-        urlWithTokenParam =
-            url
-                + "&pageToken="
-                + resp.get(DATAPLEX_API_RESP_NEXT_PAGE_TOKEN_FIELD_NAME).getAsString();
-      }
-    }
-    return entityList;
-  }
-
-  /**
    * Execute request on Google API to fetch schema of a Dataplex entity
    *
-   * @param entity name
    * @return entity schema
    * @throws IOException when request on Dataplex API fails
    */
-  private static JsonObject getEntitySchema(String entity) throws IOException {
-    String url = String.format(GET_ENTITY_METHOD_URL, entity);
+  private JsonObject getEntitySchema() throws IOException {
+    String url = String.format(GET_ENTITY_METHOD_URL, this.entity);
     return executeRequest(url);
   }
 
   /**
    * Execute request on Google API to fetch partitions of a Dataplex entity
    *
-   * @param entity name
    * @param pageToken
    * @return entity partitions
    * @throws IOException when request on Dataplex API fails
    */
-  private static JsonObject getEntityPartitions(String entity, String pageToken)
-      throws IOException {
-    String url = String.format(GET_ENTITY_PARTITIONS_METHOD_URL, entity);
+  private JsonObject getEntityPartitions(String pageToken) throws IOException {
+    String url = String.format(GET_ENTITY_PARTITIONS_METHOD_URL, this.entity);
     if (pageToken != null) {
       url += "pageToken=" + pageToken;
     }
@@ -166,25 +144,21 @@ public class DataplexUtil {
    * Execute request on Google API to fetch schema of a Dataplex entity and parses out base path of
    * entity data
    *
-   * @param entity name
    * @return source data base path
    * @throws IOException when request on Dataplex API fails
    */
-  public static String getBasePathEntityData(String entity) throws IOException {
-    JsonObject responseJson = DataplexUtil.getEntitySchema(entity);
-    return responseJson.get(ENTITY_BASE_PATH_PROP_KEY).getAsString();
+  public String getBasePathEntityData() {
+    return this.entitySchema.get(ENTITY_BASE_PATH_PROP_KEY).getAsString();
   }
 
   /**
    * Execute request on Google API to fetch schema of a Dataplex entity and parses out file format
    *
-   * @param entity name
    * @return file format
    * @throws IOException when request on Dataplex API fails
    */
-  public static String getInputFileFormat(String entity) throws IOException {
-    JsonObject responseJson = DataplexUtil.getEntitySchema(entity);
-    return responseJson
+  public String getInputFileFormat() {
+    return this.entitySchema
         .getAsJsonObject(ENTITY_FORMAT_PROP_KEY)
         .get(ENTITY_FORMAT_PROP_KEY)
         .getAsString()
@@ -195,13 +169,11 @@ public class DataplexUtil {
    * Execute request on Google API to fetch schema of a Dataplex entity and parses out the CSV
    * delimiter
    *
-   * @param entity name, must be an entity with CSV format
    * @return file format
    * @throws IOException when request on Dataplex API fails
    */
-  public static String getInputCSVDelimiter(String entity) throws IOException {
-    JsonObject responseJson = DataplexUtil.getEntitySchema(entity);
-    return responseJson
+  public String getInputCSVDelimiter() throws IOException {
+    return this.entitySchema
         .getAsJsonObject(ENTITY_FORMAT_PROP_KEY)
         .getAsJsonObject(GCS_BQ_CSV_FORMAT)
         .get(GCS_BQ_CSV_DELIMITER_PROP_NAME)
@@ -213,20 +185,18 @@ public class DataplexUtil {
    * Execute request on Google API to fetch schema of a Dataplex entity and parses out a list of
    * partition Keys
    *
-   * @param entity name
    * @return list with partition keys of the entity
    * @throws IOException when request on Dataplex API fails
    */
-  public static List<String> getPartitionKeyList(String entity) throws IOException {
-    JsonObject responseJson = DataplexUtil.getEntitySchema(entity);
+  public List<String> getPartitionKeyList() throws IOException {
+    JsonObject entitySchemaBody = this.entitySchema.getAsJsonObject(ENTITY_SCHEMA_PROP_KEY);
 
-    JsonObject entitySchema = responseJson.getAsJsonObject(ENTITY_SCHEMA_PROP_KEY);
-
-    if (!entitySchema.has(ENTITY_SCHEMA_PARTITION_FIELDS_PROP_KEY)) {
+    if (!entitySchemaBody.has(ENTITY_SCHEMA_PARTITION_FIELDS_PROP_KEY)) {
       throw new DataplexUtilNoPartitionError();
     }
 
-    JsonArray partitionKeys = entitySchema.getAsJsonArray(ENTITY_SCHEMA_PARTITION_FIELDS_PROP_KEY);
+    JsonArray partitionKeys =
+        entitySchemaBody.getAsJsonArray(ENTITY_SCHEMA_PARTITION_FIELDS_PROP_KEY);
 
     List<String> partitionFieldsNames = new ArrayList<String>();
     Iterator partitionFieldsIter = partitionKeys.iterator();
@@ -247,7 +217,7 @@ public class DataplexUtil {
    *     partition
    * @throws IOException when request on Dataplex API fails
    */
-  private static List<String> parsePartitionToStringWithLocationAndKeys(JsonObject partitions) {
+  private List<String> parsePartitionToStringWithLocationAndKeys(JsonObject partitions) {
     Iterator<JsonElement> partitionsIterator =
         partitions.getAsJsonArray(ENTITY_PARTITION_PROP_KEY).iterator();
     List<String> partitionsListWithLocationAndKeys = new ArrayList<String>();
@@ -273,20 +243,18 @@ public class DataplexUtil {
    * will return a list of string with the pattern: ["partition_path,key_1,key_2,...,key_n",
    * "partition_path,key1,key2,...,keyn", ...]
    *
-   * @param entity name
    * @return list of all partitions where each element contains gcs path and key values for a given
    *     partition
    * @throws IOException when request on Dataplex API fails
    */
-  public static List<String> getPartitionsListWithLocationAndKeys(String entity)
-      throws IOException {
+  public List<String> getPartitionsListWithLocationAndKeys() throws IOException {
     String pageToken = null;
     JsonObject responseJson = null;
     List<String> partitionsListWithLocationAndKeys = new ArrayList<String>();
     List<String> currentPartitionsListWithLocationAndKeys = new ArrayList<String>();
 
     while (true) {
-      responseJson = getEntityPartitions(entity, pageToken);
+      responseJson = getEntityPartitions(pageToken);
       currentPartitionsListWithLocationAndKeys =
           parsePartitionToStringWithLocationAndKeys(responseJson);
       partitionsListWithLocationAndKeys.addAll(currentPartitionsListWithLocationAndKeys);
@@ -306,7 +274,7 @@ public class DataplexUtil {
    *
    * @return hashmap with mapping between Dataplex datatype name and spark DataType
    */
-  public static HashMap<String, DataType> getDataplexTypeToSparkTypeMap() {
+  public HashMap<String, DataType> getDataplexTypeToSparkTypeMap() {
     HashMap<String, DataType> dataplexTypeToSparkType = new HashMap<String, DataType>();
     dataplexTypeToSparkType.put(DATAPLEX_BOOLEAN_DATA_TYPE_NAME, DataTypes.BooleanType);
     dataplexTypeToSparkType.put(DATAPLEX_BYTE_DATA_TYPE_NAME, DataTypes.ByteType);
@@ -331,7 +299,7 @@ public class DataplexUtil {
    * @param dataplexSchema schema from source Dataplex entity
    * @return a spark schema matching Dataples source entity schema
    */
-  public static List<StructField> buildSparkSchemaFromDataplexSchema(
+  public List<StructField> buildSparkSchemaFromDataplexSchema(
       List<StructField> schema,
       HashMap<String, DataType> dataplexTypeToSparkType,
       JsonArray dataplexSchema) {
@@ -384,19 +352,16 @@ public class DataplexUtil {
    * Cast fields in a dataset to match datatypes of source Dataplex entity schema
    *
    * @param inputDS dataset that will be casted to new schema
-   * @param entity dataplex source entity
    * @return a spark dataset with schema matching Dataples source entity schema
    */
-  public static Dataset<Row> castDatasetToDataplexSchema(Dataset<Row> inputDS, String entity)
-      throws IOException {
-    JsonObject entityJson = getEntitySchema(entity);
+  public Dataset<Row> castDatasetToDataplexSchema(Dataset<Row> inputDS) throws IOException {
     HashMap<String, DataType> dataplexTypeToSparkType = getDataplexTypeToSparkTypeMap();
     JsonArray dataplexSchema =
-        entityJson
+        this.entitySchema
             .getAsJsonObject(ENTITY_SCHEMA_PROP_KEY)
             .getAsJsonArray(ENTITY_SCHEMA_FIELDS_PROP_NAME);
     JsonArray dataplexPartitionSchema =
-        entityJson
+        this.entitySchema
             .getAsJsonObject(ENTITY_SCHEMA_PROP_KEY)
             .getAsJsonArray(ENTITY_SCHEMA_PARTITION_FIELDS_PROP_KEY);
 
@@ -417,7 +382,7 @@ public class DataplexUtil {
     return inputDS.selectExpr(selectExpresions.toArray(new String[0]));
   }
 
-  public static class DataplexUtilNoPartitionError extends RuntimeException {
+  public class DataplexUtilNoPartitionError extends RuntimeException {
     public DataplexUtilNoPartitionError() {
       super("The entity has no partitions");
     }

--- a/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/util/TemplateConstants.java
@@ -220,6 +220,8 @@ public interface TemplateConstants {
   /** Dataplex GCS to BQ */
   String DATAPLEX_GCS_BQ_TARGET_DATASET = "dataplex.gcs.bq.target.dataset";
 
+  String DATAPLEX_GCS_BQ_TARGET_ASSET = "dataplex.gcs.bq.target.asset";
+  String DATAPLEX_GCS_BQ_TARGET_ENTITY = "dataplex.gcs.bq.target.entity";
   String DATAPLEX_GCS_BQ_SAVE_MODE = "dataplex.gcs.bq.save.mode";
   String DATAPLEX_GCS_BQ_INCREMENTAL_PARTITION_COPY = "dataplex.gcs.bq.incremental.partition.copy";
   String DATAPLEX_GCS_BQ_BASE_PATH_PROP_NAME = "basePath";
@@ -234,6 +236,7 @@ public interface TemplateConstants {
   String INTERMEDIATE_FORMAT_OPTION_NAME = "intermediateFormat";
   String INTERMEDIATE_FORMAT_ORC = "orc";
   String SPARK_SAVE_MODE_OVERWRITE = "overwrite";
+  String BQ_TABLE_NAME_FORMAT = "%s.%s.%s";
 
   /** KafkaToBQ properties */
   String KAFKA_BQ_CHECKPOINT_LOCATION = "kafka.bq.checkpoint.location";

--- a/java/src/main/resources/template.properties
+++ b/java/src/main/resources/template.properties
@@ -216,7 +216,9 @@ hbasetogcs.output.path=
 hbasetogcs.table.catalog=
 
 # Dataplex GCS to BQ
-dataplex.gcs.bq.target.dataset=<bq target dataset>
+dataplex.gcs.bq.target.dataset=
+dataplex.gcs.bq.target.asset=
+dataplex.gcs.bq.target.entity=
 dataplex.gcs.bq.save.mode="errorifexists"
 dataplex.gcs.bq.incremental.partition.copy="yes"
 


### PR DESCRIPTION
This PR covers the following:

- Refactoring the Dataplex utils to avoid duplicate API calls
- Adding support for Dataplex targets. No users can specify Dataplex BQ Assets and Entities as targets