### PR TITLE
enable Spark level logging

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -61,7 +61,22 @@ A shell script is provided to:
 - Build the python package
 - Set Dataproc parameters based on environment variables
 - Submit the desired template to Dataproc with the provided template parameters
- 
+
+<hr>
+
+When submitting, there are 3 types of properties/parameters for the user to provide.  
+- **Spark properties**: Refer to this [documentation](https://cloud.google.com/dataproc-serverless/docs/concepts/properties) to see the available spark properties.
+- **Each template's specific parameters**: refer to each template's README.
+- **Common arguments**: --template_name and --log_level
+  - The **--log_level** parameter is optional, it defaults to INFO.
+    - Possible choices are the Spark log levels: ["ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"].
+
+
+
+
+
+<hr>
+
 **bin/start.sh usage**:
 
 ```
@@ -79,6 +94,7 @@ export METASTORE_SERVICE=projects/{projectId}/locations/{regionId}/services/{ser
 # Submit to Dataproc passing template parameters
 ./bin/start.sh [--properties=<spark.something.key>=<value>] \
                -- --template=TEMPLATENAME \
+                  --log_level=INFO \
                   --my.property="<value>" \
                   --my.other.property="<value>"
                   (etc...)
@@ -110,16 +126,12 @@ gcloud dataproc batches submit pyspark \
       [--properties=<spark.something.key>=<value>] \
       main.py \
       -- --template=TEMPLATENAME \
+         --log_level=INFO \
          --<my.property>="<value>" \
          --<my.other.property>="<value>"
          (etc...)
 ```
 
-To see each template's specific parameters, refer to each template's README.
-
-Refer to this [documentation](https://cloud.google.com/dataproc-serverless/docs/concepts/properties) to see the available spark properties.
-
-
 **Vertex AI usage**:
 
-Follow [Dataproc Templates (Jupyter Notebooks) README](../notebooks/README.md) to submit Dataproc Templates from a Vertex AI notebook.  
+Follow [Dataproc Templates (Jupyter Notebooks) README](../notebooks/README.md) to submit Dataproc Templates from a Vertex AI notebook.

--- a/python/dataproc_templates/util/__init__.py
+++ b/python/dataproc_templates/util/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .argument_parsing import get_template_name
+from .argument_parsing import get_template_name, get_log_level
 from .tracking import track_template_invocation

--- a/python/dataproc_templates/util/argument_parsing.py
+++ b/python/dataproc_templates/util/argument_parsing.py
@@ -55,3 +55,40 @@ def get_template_name(args: Optional[Sequence[str]] = None) -> TemplateName:
         parser.exit()
 
     return TemplateName.from_string(known_args.template_name)
+
+
+def get_log_level(args: Optional[Sequence[str]] = None) -> str:
+    """
+    Parses the log level option from the program arguments.
+
+    INFO is the default log level
+    This will exit if the log level in an invalid choice.
+
+    Args:
+        args (Optional[Sequence[str]]): The program arguments.
+            By default, command line arguments will be used.
+
+    Returns:
+        str: The value of the --log_level argument
+    """
+
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        add_help=False
+    )
+
+    parser.add_argument(
+        '--log_level',
+        dest='log_level',
+        type=str,
+        required=False,
+        default="INFO",
+        choices=["ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"],
+        help='Spark Context Log Level'
+    )
+
+    known_args: argparse.Namespace
+    known_args, _ = parser.parse_known_args(args=args)
+
+    return known_args.log_level
+
+

--- a/python/main.py
+++ b/python/main.py
@@ -21,7 +21,7 @@ from pyspark.sql import SparkSession
 from dataproc_templates import BaseTemplate, TemplateName
 from dataproc_templates.gcs.gcs_to_jdbc import GCSToJDBCTemplate
 from dataproc_templates.mongo.mongo_to_gcs import MongoToGCSTemplate
-from dataproc_templates.util import get_template_name, track_template_invocation
+from dataproc_templates.util import get_template_name, get_log_level, track_template_invocation
 from dataproc_templates.gcs.gcs_to_bigquery import GCSToBigQueryTemplate
 from dataproc_templates.gcs.gcs_to_gcs import GCSToGCSTemplate
 from dataproc_templates.gcs.gcs_to_mongo import GCSToMONGOTemplate
@@ -37,10 +37,7 @@ from dataproc_templates.jdbc.jdbc_to_bigquery import JDBCToBigQueryTemplate
 from dataproc_templates.snowflake.snowflake_to_gcs import SnowflakeToGCSTemplate
 from dataproc_templates.redshift.redshift_to_gcs import RedshiftToGCSTemplate
 
-
-
 LOGGER: logging.Logger = logging.getLogger('dataproc_templates')
-
 
 # Maps each TemplateName to its corresponding implementation
 # of BaseTemplate
@@ -64,7 +61,6 @@ TEMPLATE_IMPLS: Dict[TemplateName, Type[BaseTemplate]] = {
 
 }
 
-
 def create_spark_session(template_name: TemplateName) -> SparkSession:
     """
     Creates the SparkSession object.
@@ -84,7 +80,7 @@ def create_spark_session(template_name: TemplateName) -> SparkSession:
         .appName(template_name.value) \
         .enableHiveSupport() \
         .getOrCreate()
-    spark.sparkContext.setLogLevel("INFO")
+    spark.sparkContext.setLogLevel(get_log_level())
 
     return spark
 
@@ -105,8 +101,6 @@ def run_template(template_name: TemplateName) -> None:
 
     template_impl: Type[BaseTemplate] = TEMPLATE_IMPLS[template_name]
 
-    LOGGER.info('Running template %s', template_name.value)
-
     template_instance: BaseTemplate = template_impl.build()
 
     try:
@@ -126,7 +120,6 @@ def run_template(template_name: TemplateName) -> None:
 
 
 if __name__ == '__main__':
-    LOGGER.setLevel(logging.INFO)
 
     run_template(
         template_name=get_template_name()

--- a/python/test/util/test_argument_parsing.py
+++ b/python/test/util/test_argument_parsing.py
@@ -19,7 +19,7 @@ from typing import List
 import pytest
 
 from dataproc_templates import TemplateName
-from dataproc_templates.util.argument_parsing import get_template_name
+from dataproc_templates.util.argument_parsing import get_template_name, get_log_level
 
 
 def test_get_valid_template_names():
@@ -32,9 +32,24 @@ def test_get_valid_template_names():
         )
         assert template_name == parsed_template_name.value
 
-
 def test_get_invalid_template_name():
     """Tests that an invalid template name raises an error"""
     template_name = "GCSTOSMALLQUERY"
     with pytest.raises(SystemExit):
         get_template_name(["--template=" + template_name])
+
+def test_get_valid_log_level():
+    """Tests valid log levels"""
+    log_levels: List[str] = ["ALL", "DEBUG", "ERROR", "FATAL", "INFO", "OFF", "TRACE", "WARN"]
+
+    for log_level in log_levels:
+        parsed_log_level: str = get_log_level(
+            args=["--log_level",  log_level]
+        )
+        assert log_level == parsed_log_level
+
+def test_get_invalid_log_level():
+    """Tests that an invalid log level raises an error"""
+    log_level = "AWESOME_LOG_LEVEL"
+    with pytest.raises(SystemExit):
+        get_template_name(["--log_level=" + log_level])


### PR DESCRIPTION
This PR enables to user to provide Spark log levels as a parameter for the PySpark templates.
Default log level is set to INFO.
The parameter is optional, and it will be considered for all templates.
The documentation of it is in the python/README.md as it applies to all templates.

Closes #386 