### PR TITLE
Updated Google-auth python package

### DIFF
--- a/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
+++ b/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
@@ -78,6 +78,7 @@
     "# Google Cloud notebooks requires dependencies to be installed with '--user'\n",
     "! pip3 install pyspark\n",
     "! pip3 install --upgrade google-cloud-pipeline-components kfp --user -q\n",
+    "! pip3 install pip install google-auth==2.13.0\n",
     "# Install latest JDK\n",
     "! sudo apt-get update\n",
     "! sudo apt-get install default-jdk -y"
@@ -478,9 +479,9 @@
  "metadata": {
   "environment": {
    "kernel": "python3",
-   "name": "common-cpu.m97",
+   "name": "common-cpu.m100",
    "type": "gcloud",
-   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m97"
+   "uri": "gcr.io/deeplearning-platform-release/base-cpu:m100"
   },
   "kernelspec": {
    "display_name": "Python 3",


### PR DESCRIPTION
Due to recent changes in the google-auth-library-python-oauth module python was not able to connect to GCS and thus was not able to save audit data as csv in GCS.

Ref: https://github.com/googleapis/google-auth-library-python-oauthlib/pull/240/files#diff-63cdf7d9059947cf2f03b72a8137b8a1901de52f685705c251886d58a75b9381L8

Updates Google-auth library to required package to fix the issue.