### PR TITLE
Issue 406: [Notebook] Oracle Instant Client Step Needs Updating

### DIFF
--- a/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
+++ b/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
@@ -108,7 +108,7 @@
     "sudo mkdir -p /opt/oracle\n",
     "sudo rm -fr /opt/oracle/instantclient*\n",
     "cd /opt/oracle\n",
-    "sudo wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
+    "sudo wget --no-verbose https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
     "sudo unzip instantclient-basic-linuxx64.zip\n",
     "INSTANT_CLIENT_DIR=$(find /opt/oracle -maxdepth 1 -type d -name \"instantclient_[0-9]*_[0-9]*\" | sort | tail -1)\n",
     "test -n \"${INSTANT_CLIENT_DIR}\" || echo \"ERROR: Could not find instant client\"\n",
@@ -484,8 +484,8 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "wget https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/21.7.0.0/ojdbc8-21.7.0.0.jar\n",
-    "wget https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.27.0/spark-bigquery-with-dependencies_2.12-0.27.0.jar"
+    "wget --no-verbose https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/21.7.0.0/ojdbc8-21.7.0.0.jar\n",
+    "wget --no-verbose https://repo1.maven.org/maven2/com/google/cloud/spark/spark-bigquery-with-dependencies_2.12/0.27.0/spark-bigquery-with-dependencies_2.12-0.27.0.jar"
    ]
   },
   {

--- a/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
+++ b/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
@@ -106,13 +106,17 @@
    "source": [
     "%%bash\n",
     "sudo mkdir -p /opt/oracle\n",
+    "sudo rm -fr /opt/oracle/instantclient*\n",
     "cd /opt/oracle\n",
     "sudo wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
     "sudo unzip instantclient-basic-linuxx64.zip\n",
+    "INSTANT_CLIENT_DIR=$(find /opt/oracle -maxdepth 1 -type d -name \"instantclient_[0-9]*_[0-9]*\" | sort | tail -1)\n",
+    "test -n \"${INSTANT_CLIENT_DIR}\" || echo \"ERROR: Could not find instant client\"\n",
+    "test -n \"${INSTANT_CLIENT_DIR}\" || exit 1\n",
     "sudo apt-get install libaio1\n",
-    "sudo sh -c \"echo /opt/oracle/instantclient_21_6 > /etc/ld.so.conf.d/oracle-instantclient.conf\"\n",
+    "sudo sh -c \"echo ${INSTANT_CLIENT_DIR} > /etc/ld.so.conf.d/oracle-instantclient.conf\"\n",
     "sudo ldconfig\n",
-    "export LD_LIBRARY_PATH=/opt/oracle/instantclient_21_6:$LD_LIBRARY_PATH"
+    "export LD_LIBRARY_PATH=${INSTANT_CLIENT_DIR}:$LD_LIBRARY_PATH"
    ]
   },
   {

--- a/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
+++ b/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
@@ -119,7 +119,7 @@
     "sudo mkdir -p /opt/oracle\n",
     "sudo rm -fr /opt/oracle/instantclient*\n",
     "cd /opt/oracle\n",
-    "sudo wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
+    "sudo wget --no-verbose https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
     "sudo unzip instantclient-basic-linuxx64.zip\n",
     "INSTANT_CLIENT_DIR=$(find /opt/oracle -maxdepth 1 -type d -name \"instantclient_[0-9]*_[0-9]*\" | sort | tail -1)\n",
     "test -n \"${INSTANT_CLIENT_DIR}\" || echo \"ERROR: Could not find instant client\"\n",
@@ -502,7 +502,7 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/21.7.0.0/ojdbc8-21.7.0.0.jar\n",
+    "!wget --no-verbose https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/21.7.0.0/ojdbc8-21.7.0.0.jar\n",
     "!mvn clean spotless:apply install -DskipTests \n",
     "!mvn dependency:get -Dartifact=io.grpc:grpc-grpclb:1.40.1 -Dmaven.repo.local=./grpc_lb "
    ]

--- a/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
+++ b/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
@@ -116,15 +116,18 @@
    "outputs": [],
    "source": [
     "%%bash\n",
-    "sudo rm -r /opt/oracle/*\n",
     "sudo mkdir -p /opt/oracle\n",
+    "sudo rm -fr /opt/oracle/instantclient*\n",
     "cd /opt/oracle\n",
     "sudo wget https://download.oracle.com/otn_software/linux/instantclient/instantclient-basic-linuxx64.zip\n",
     "sudo unzip instantclient-basic-linuxx64.zip\n",
+    "INSTANT_CLIENT_DIR=$(find /opt/oracle -maxdepth 1 -type d -name \"instantclient_[0-9]*_[0-9]*\" | sort | tail -1)\n",
+    "test -n \"${INSTANT_CLIENT_DIR}\" || echo \"ERROR: Could not find instant client\"\n",
+    "test -n \"${INSTANT_CLIENT_DIR}\" || exit 1\n",
     "sudo apt-get install libaio1\n",
-    "sudo sh -c \"echo /opt/oracle/instantclient_21_6 > /etc/ld.so.conf.d/oracle-instantclient.conf\"\n",
+    "sudo sh -c \"echo ${INSTANT_CLIENT_DIR} > /etc/ld.so.conf.d/oracle-instantclient.conf\"\n",
     "sudo ldconfig\n",
-    "export LD_LIBRARY_PATH=/opt/oracle/instantclient_21_6:$LD_LIBRARY_PATH"
+    "export LD_LIBRARY_PATH=${INSTANT_CLIENT_DIR}:$LD_LIBRARY_PATH"
    ]
   },
   {


### PR DESCRIPTION
These changes update the Oracle based notebooks to dynamically define the name of the instance client directory. Previously the name was hardcoded and had become out of date, this required the end user to fix.

Changed notebooks:

- oracle2bq/OracleToBigQuery_notebook.ipynb
- oracle2spanner/OracleToSpanner_notebook.ipynb

As part of these changes I also added `--no-verbose` options to `wget` commands. I only did this to the two notebooks I was changing for this issue. If these changes make it to main I'll raise another issue to do the same to other notebooks.

I've tested manually and also run this branch through integration-tests-python and build-job-python in Jenkins.