### PR TITLE
#Issue 346: Workaround for hardcoded working dir 

### DIFF
--- a/notebooks/generic_notebook/vertex_pipeline_pyspark.ipynb
+++ b/notebooks/generic_notebook/vertex_pipeline_pyspark.ipynb
@@ -130,7 +130,8 @@
     "import google.cloud.aiplatform as aiplatform\n",
     "from kfp import dsl\n",
     "from kfp.v2 import compiler\n",
-    "from datetime import datetime"
+    "from datetime import datetime\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -148,8 +149,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
-    "%cd /home/jupyter/dataproc-templates/python"
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69752c22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%cd $WORKING_DIRECTORY"
    ]
   },
   {
@@ -343,7 +361,7 @@
    "uri": "gcr.io/deeplearning-platform-release/base-cpu:m91"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.9.6 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -357,7 +375,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.6"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
+++ b/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
@@ -178,7 +178,8 @@
     "import time\n",
     "import os\n",
     "from pyspark.sql import SparkSession\n",
-    "import pandas as pd\n"
+    "import pandas as pd\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -193,12 +194,29 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "da510653",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "d6e0e80a-e8b7-4e54-9f99-b7874e164978",
    "metadata": {},
    "outputs": [],
    "source": [
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python\"\n",
-    "%cd /home/jupyter/dataproc-templates/python"
+    "%cd $WORKING_DIRECTORY"
    ]
   },
   {
@@ -484,7 +502,7 @@
    "uri": "gcr.io/deeplearning-platform-release/base-cpu:m100"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.10.8 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -498,7 +516,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
+   }
   }
  },
  "nbformat": 4,

--- a/notebooks/mssql2bq/mssql-to-bigquery-notebook.ipynb
+++ b/notebooks/mssql2bq/mssql-to-bigquery-notebook.ipynb
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "import google.cloud.aiplatform as aiplatform\n",
-    "import sys\n",
+    "import sys, os\n",
     "from kfp import dsl\n",
     "from kfp.v2 import compiler\n",
     "from datetime import datetime\n",
@@ -127,7 +127,8 @@
     "from google_cloud_pipeline_components.experimental.dataproc import DataprocPySparkBatchOp\n",
     "import sqlalchemy\n",
     "import pymssql\n",
-    "import math"
+    "import math\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -259,9 +260,26 @@
     "JDBC_DRIVER = \"com.microsoft.sqlserver.jdbc.SQLServerDriver\"\n",
     "JDBC_URL = \"jdbc:sqlserver://{}:{};databaseName={};user={};password={}\".format(SQL_SERVER_HOST,SQL_SERVER_PORT,SQL_SERVER_DATABASE,SQL_SERVER_USERNAME,SQL_SERVER_PASSWORD)\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
     "PACKAGE_EGG_FILE = \"dataproc_templates_distribution.egg\"\n",
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6960dba0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
    ]
   },
   {
@@ -829,7 +847,7 @@
    "uri": "gcr.io/deeplearning-platform-release/base-cpu:m97"
   },
   "kernelspec": {
-   "display_name": "Python 3.7.7 ('venv': venv)",
+   "display_name": "Python 3.10.8 64-bit",
    "language": "python",
    "name": "python3"
   },
@@ -843,11 +861,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.10.8"
   },
   "vscode": {
    "interpreter": {
-    "hash": "6c3e1d48c09e08a12993d6ae9cc00c9681c16c107182e7277a546cd05925114c"
+    "hash": "b0fa6594d8f4cbf19f97940f81e996739fb7646882a419484c72d19e05852a7e"
    }
   }
  },

--- a/notebooks/mssql2postgresql/mssql-to-postgres-notebook.ipynb
+++ b/notebooks/mssql2postgresql/mssql-to-postgres-notebook.ipynb
@@ -136,7 +136,9 @@
     "from google_cloud_pipeline_components.experimental.dataproc import DataprocPySparkBatchOp\n",
     "import sqlalchemy\n",
     "import pymssql\n",
-    "import math"
+    "import math\n",
+    "from pathlib import Path\n",
+    "import os"
    ]
   },
   {
@@ -254,6 +256,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "f204af9b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "34123cf3-4ce0-49c6-b7b9-ed40f4fb199f",
    "metadata": {},
    "outputs": [],
@@ -262,7 +282,6 @@
     "JDBC_INPUT_DRIVER=\"com.microsoft.sqlserver.jdbc.SQLServerDriver\"\n",
     "JDBC_INPUT_URL=\"jdbc:sqlserver://{0}:{1};databaseName={2};user={3};password={4}\".format(MSSQL_HOST,MSSQL_PORT,MSSQL_DATABASE,MSSQL_USERNAME,MSSQL_PASSWORD)\n",
     "MAIN_CLASS=\"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
-    "WORKING_DIRECTORY=\"/home/jupyter/dataproc-templates/python/\"\n",
     "JDBC_OUTPUT_DRIVER=\"org.postgresql.Driver\"\n",
     "JDBC_OUTPUT_URL=\"jdbc:postgresql://{0}:{1}/{2}?user={3}&password={4}\".format(POSTGRES_HOST,POSTGRES_PORT,POSTGRES_DATABASE,POSTGRES_USERNAME,POSTGRES_PASSWORD)\n",
     "PACKAGE_EGG_FILE=\"dist/dataproc_templates_distribution.egg\"\n",
@@ -850,7 +869,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {

--- a/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
+++ b/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
@@ -145,7 +145,9 @@
     "import copy\n",
     "import json\n",
     "import pandas as pd\n",
-    "from google_cloud_pipeline_components.experimental.dataproc import DataprocSparkBatchOp"
+    "from google_cloud_pipeline_components.experimental.dataproc import DataprocSparkBatchOp\n",
+    "from pathlib import Path\n",
+    "import os"
    ]
   },
   {
@@ -243,6 +245,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "367f66b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
     "tags": []
@@ -253,7 +273,6 @@
     "JDBC_DRIVER = \"com.mysql.cj.jdbc.Driver\"\n",
     "JDBC_URL = \"jdbc:mysql://{}:{}/{}?user={}&password={}\".format(MYSQL_HOST,MYSQL_PORT,MYSQL_DATABASE,MYSQL_USERNAME,MYSQL_PASSWORD)\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/java/\"\n",
     "JAR_FILE = \"dataproc-templates-1.0-SNAPSHOT.jar\"\n",
     "GRPC_JAR_PATH = \"./grpc_lb/io/grpc/grpc-grpclb/1.40.1\"\n",
     "GRPC_JAR = \"grpc-grpclb-1.40.1.jar\"\n",

--- a/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
+++ b/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
@@ -170,7 +170,9 @@
     "import json\n",
     "import math\n",
     "import pandas as pd\n",
-    "from google_cloud_pipeline_components.experimental.dataproc import DataprocPySparkBatchOp"
+    "from google_cloud_pipeline_components.experimental.dataproc import DataprocPySparkBatchOp\n",
+    "import os\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -282,6 +284,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8fa610c5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
     "tags": []
@@ -293,7 +313,6 @@
     "JDBC_URL = \"jdbc:oracle:thin:{}/{}@{}:{}/{}\".format(ORACLE_USERNAME,ORACLE_PASSWORD,ORACLE_HOST,ORACLE_PORT,ORACLE_DATABASE)\n",
     "JDBC_FETCH_SIZE = 200\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
     "PACKAGE_EGG_FILE = \"dataproc_templates_distribution.egg\"\n",
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\""
    ]

--- a/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
+++ b/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
@@ -172,7 +172,7 @@
    "outputs": [],
    "source": [
     "import sqlalchemy\n",
-    "import math\n",
+    "import math ,os\n",
     "import google.cloud.aiplatform as aiplatform\n",
     "from kfp import dsl\n",
     "from kfp.v2 import compiler\n",
@@ -181,6 +181,7 @@
     "import copy\n",
     "import json\n",
     "import pandas as pd\n",
+    "from pathlib import Path\n",
     "from google_cloud_pipeline_components.experimental.dataproc import DataprocSparkBatchOp"
    ]
   },
@@ -302,6 +303,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "bcb42b2f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cur_path = Path(os.getcwd())\n",
+    "WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')\n",
+    "\n",
+    "# If the above code doesn't fetches the correct path please\n",
+    "# provide complete path to python folder in your dataproc \n",
+    "# template repo which you cloned \n",
+    "\n",
+    "# WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/python/\"\n",
+    "print(WORKING_DIRECTORY)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
     "tags": []
@@ -313,7 +332,6 @@
     "JDBC_URL = \"jdbc:oracle:thin:{}/{}@{}:{}/{}\".format(ORACLE_USERNAME,ORACLE_PASSWORD,ORACLE_HOST,ORACLE_PORT,ORACLE_DATABASE)\n",
     "JDBC_FETCH_SIZE = 200\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
-    "WORKING_DIRECTORY = \"/home/jupyter/dataproc-templates/java/\"\n",
     "JAR_FILE = \"dataproc-templates-1.0-SNAPSHOT.jar\"\n",
     "GRPC_JAR_PATH = \"./grpc_lb/io/grpc/grpc-grpclb/1.40.1\"\n",
     "GRPC_JAR = \"grpc-grpclb-1.40.1.jar\"\n",
@@ -872,7 +890,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.12"
+   "version": "3.9.6"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
[Issue Link](  https://github.com/GoogleCloudPlatform/dataproc-templates/issues/346
)

For this I have used os.getcwd() in places where I found the parameter 'WORKING_DIRECTORY'  hardcoded in each notebooks.  
Earlier path used in notebooks were  like this
` WORKING_DIRECTORY = "/home/jupyter/dataproc-templates/python/"`
What I did is used os.getcwd() to get current directory and naviagate to python folder using that.  This will work in case we are running it locally however when using PySpark hive cluster os.getcwd() will return '/' hence we need to manually set the directory path . Thus i have written this as a comment in notebook.

`cur_path = Path(os.getcwd())`
`WORKING_DIRECTORY = os.path.join(cur_path.parent.parent ,'python')`

`# If the above code doesn't fetches the correct path please`
`# provide complete path to python folder in your dataproc `
`# template repo which you cloned `

`# WORKING_DIRECTORY = "/home/jupyter/dataproc-templates/python/"`
`print(WORKING_DIRECTORY)`

This change was done in all 7 notebooks.
