### PR TITLE
feat: Added optional arguments to make DDL compatible with Spark Tables and BQ Translation API

### DIFF
--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -2,9 +2,7 @@
 
 This is a PySpark utility to extract DDLs of all the tables from a HIVE database using Hive Metastore. Users can use this utility to accelerate their Hive migration journey.  
 
-It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to a GCS bucket path, creating it with the following sub-path: *"/<database-name>/%m-%d-%Y %H.%M.%S/part-00000"*.  
-
-Note that it uses the "SHOW CREATE TABLE <...> AS SERDE" statement. Feel free to remove the AS SERDE suffix if you need DDLs of tables created using Spark.
+It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to the given GCS bucket path with the name as <HIVE_DB>.sql
 
 ## Arguments
 

--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -2,7 +2,7 @@
 
 This is a PySpark utility to extract DDLs of all the tables from a HIVE database using Hive Metastore. Users can use this utility to accelerate their Hive migration journey.  
 
-It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to the given GCS bucket path with the name as <HIVE_DB>.sql
+It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to a GCS bucket path, creating it with the following sub-path: "//%m-%d-%Y %H.%M.%S/part-00000".
 
 ## Arguments
 

--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -13,7 +13,7 @@ It queries Hive Metastore via thrift to get DDLs for each table in the database,
 ## Optional Arguments
 
 * `hive.ddl.consider.spark.tables`: Flag to extract DDL of Spark tables 
-* `hive.ddl.translation.disposition`: Flag to remove location parameter from HIVE DDL
+* `hive.ddl.translation.disposition`: Flag to remove location parameter from HIVE DDL to make DDL compatible with BQ Translation API
 
 ## Usage
 

--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -2,7 +2,7 @@
 
 This is a PySpark utility to extract DDLs of all the tables from a HIVE database using Hive Metastore. Users can use this utility to accelerate their Hive migration journey.  
 
-It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to a GCS bucket path, creating it with the following sub-path: "//%m-%d-%Y %H.%M.%S/part-00000".
+It queries Hive Metastore via thrift to get DDLs for each table in the database, and outputs a single text file of semicolon-separated DDLs to a GCS bucket path, creating it with the following sub-path: "//hive_database/part-00000".
 
 ## Arguments
 

--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -12,6 +12,11 @@ Note that it uses the "SHOW CREATE TABLE <...> AS SERDE" statement. Feel free to
 * `hive.ddl.extractor.input.database`: Hive database for input table  
 * `hive.ddl.extractor.output.path`: Output GCS path. Ex: gs://bucket-name/path/to/directory  
 
+## Optional Arguments
+
+* `hive.ddl.consider.spark.tables`: Flag to extract DDL of Spark tables 
+* `hive.ddl.translation.disposition`: Flag to remove location parameter from HIVE DDL
+
 ## Usage
 
 ```
@@ -27,6 +32,8 @@ optional arguments:
                         Hive database for importing DDLs to GCS
   --hive.ddl.extractor.output.path HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH
                         GCS directory path e.g gs://bucket-name/path/to/directory
+  --hive.ddl.extractor.input.database HIVE_DDL_CONSIDER_SPARK_TABLES
+                        True / False
 ```
 
 ## Example submission
@@ -41,4 +48,5 @@ export SUBNET=<subnet>
     -- --template=HIVEDDLEXTRACTOR \
     --hive.ddl.extractor.input.database="<database>" \
     --hive.ddl.extractor.output.path="<gs://bucket-name/path/to/directory>"
+    --hive.ddl.extractor.input.database=True
 ```

--- a/python/dataproc_templates/hive/util/README.md
+++ b/python/dataproc_templates/hive/util/README.md
@@ -13,25 +13,26 @@ It queries Hive Metastore via thrift to get DDLs for each table in the database,
 ## Optional Arguments
 
 * `hive.ddl.consider.spark.tables`: Flag to extract DDL of Spark tables 
-* `hive.ddl.translation.disposition`: Flag to remove location parameter from HIVE DDL to make DDL compatible with BQ Translation API
+* `hive.ddl.translation.disposition`: Flag to remove location parameter from HIVE DDL to make DDL compatible with BigQuery SQL translator (the translated query will be a native BQ table and not an external one
 
 ## Usage
 
 ```
 $ python main.py --template HIVEDDLEXTRACTOR --help
 
-usage: main.py --template HIVEDDLEXTRACTOR [-h] \
-    --hive.ddl.extractor.input.database HIVE.DDL.EXTRACTOR.INPUT.DATABASE \
-    --hive.ddl.extractor.output.path HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH
+usage: main.py [-h] --hive.ddl.extractor.input.database HIVE.DDL.EXTRACTOR.INPUT.DATABASE --hive.ddl.extractor.output.path HIVE.DDL.EXTRACTOR.OUTPUT.PATH
+               [--hive.ddl.consider.spark.tables HIVE.DDL.CONSIDER.SPARK.TABLES] [--hive.ddl.translation.disposition HIVE.DDL.TRANSLATION.DISPOSITION]
 
 optional arguments:
   -h, --help            show this help message and exit
   --hive.ddl.extractor.input.database HIVE.DDL.EXTRACTOR.INPUT.DATABASE
-                        Hive database for importing DDLs to GCS
-  --hive.ddl.extractor.output.path HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH
-                        GCS directory path e.g gs://bucket-name/path/to/directory
-  --hive.ddl.extractor.input.database HIVE_DDL_CONSIDER_SPARK_TABLES
-                        True / False
+                        Hive database for importing data to BigQuery
+  --hive.ddl.extractor.output.path HIVE.DDL.EXTRACTOR.OUTPUT.PATH
+                        GCS output path
+  --hive.ddl.consider.spark.tables HIVE.DDL.CONSIDER.SPARK.TABLES
+                        Flag to extract DDL of Spark tables
+  --hive.ddl.translation.disposition HIVE.DDL.TRANSLATION.DISPOSITION
+                        Remove location parameter from HIVE DDL if set to TRUE, to be compatible with BigQuery SQL translator (the translated query will be a native BQ table and not an external one.
 ```
 
 ## Example submission
@@ -46,5 +47,6 @@ export SUBNET=<subnet>
     -- --template=HIVEDDLEXTRACTOR \
     --hive.ddl.extractor.input.database="<database>" \
     --hive.ddl.extractor.output.path="<gs://bucket-name/path/to/directory>"
-    --hive.ddl.extractor.input.database=True
+    --hive.ddl.consider.spark.tables=false \
+    --hive.ddl.translation.disposition=false
 ```

--- a/python/dataproc_templates/hive/util/hive_ddl_extractor.py
+++ b/python/dataproc_templates/hive/util/hive_ddl_extractor.py
@@ -91,8 +91,8 @@ class HiveDDLExtractorTemplate(BaseTemplate):
 
         def get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag):
             ddl_str = spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} {spark_tbls_opt}").rdd.map(lambda x: x[0]).collect()[0]
-            ddl = ddl_str if str(remove_location_flag).upper() != "TRUE" else ddl_str.split("\nLOCATION '")[0].split("\nUSING ")[0]
-            return ddl+";"
+            ddl = (ddl_str if str(remove_location_flag).upper() != "TRUE" else ddl_str.split("\nLOCATION '")[0].split("\nUSING ")[0])+";"
+            return ddl
 
         output_path = gcs_output_path+"/"+hive_database
         spark_tbls_opt = "" if str(spark_tbls_flag).upper() == "TRUE" else "AS SERDE"

--- a/python/dataproc_templates/hive/util/hive_ddl_extractor.py
+++ b/python/dataproc_templates/hive/util/hive_ddl_extractor.py
@@ -24,7 +24,7 @@ import dataproc_templates.util.template_constants as constants
 from dataproc_templates import BaseTemplate
 from pyspark.sql import SparkSession
 from datetime import datetime
-
+from google.cloud import storage
 
 class HiveDDLExtractorTemplate(BaseTemplate): 
     """
@@ -49,6 +49,22 @@ class HiveDDLExtractorTemplate(BaseTemplate):
             help='GCS output path'
         )
        
+        parser.add_argument(
+            f'--{constants.HIVE_DDL_CONSIDER_SPARK_TABLES}',
+            dest=constants.HIVE_DDL_CONSIDER_SPARK_TABLES,
+            required=False,
+            default=False,
+            help='Flag to extract DDL of Spark tables'
+        )
+
+        parser.add_argument(
+            f'--{constants.HIVE_DDL_TRANSLATION_DISPOSITION}',
+            dest=constants.HIVE_DDL_TRANSLATION_DISPOSITION,
+            required=False,
+            default=False,
+            help='Remove location parameter from HIVE DDL if set to TRUE'
+        )
+
         known_args: argparse.Namespace
         known_args, _ = parser.parse_known_args(args)
 
@@ -65,22 +81,36 @@ class HiveDDLExtractorTemplate(BaseTemplate):
 
         hive_database: str = args[constants.HIVE_DDL_EXTRACTOR_INPUT_DATABASE]
         gcs_output_path: str = args[constants.HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH]
+        spark_tbls_flag: bool = args[constants.HIVE_DDL_CONSIDER_SPARK_TABLES]
+        remove_location_flag: bool = args[constants.HIVE_DDL_TRANSLATION_DISPOSITION]
+        gcs_bucket: str = gcs_output_path.split("gs://")[1].split("/")[0]
+        gcs_output_path: str = gcs_output_path.split("gs://")[1].split("/",maxsplit=1)[1]
 
         logger.info(
                 "Starting Hive DDL Extraction job with parameters:\n"
                 f"{pprint.pformat(args)}"
             )
         
-               
-        def get_ddl(hive_database, table_name):
-            return spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} AS SERDE").rdd.map(lambda x: x[0] + ";").collect()[0]
+        def WriteToCloud(ddl, bucket, path, hive_database):
+            """
+            Write String as a file to GCS
+            """
+            print("Writing DDL to GCS: " + hive_database)
+            client = storage.Client()
+            bucket = client.get_bucket(bucket)
+            blob = bucket.blob(path + "/" + hive_database + ".sql")
+            blob.upload_from_string(ddl)
 
-        ct = datetime.now().strftime("%m-%d-%Y %H.%M.%S")
-        output_path = gcs_output_path+"/"+hive_database+"/"+str(ct)
 
+        def get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag):
+            ddl_str = spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} {spark_tbls_opt}").rdd.map(lambda x: x[0] + ";").collect()[0]
+            ddl = ddl_str if str(remove_location_flag).upper() != "TRUE" else ddl_str.split("\nLOCATION '")[0].split("\nUSING ")[0]
+            return ddl
+
+        spark_tbls_opt = "" if str(spark_tbls_flag).upper() == "TRUE" else "AS SERDE"
         tables_names = spark.sql(f"SHOW TABLES IN {hive_database}").select("tableName")
         tables_name_list = tables_names.rdd.map(lambda x: x[0]).collect()
-        tables_ddls = [ get_ddl(hive_database, table_name) for table_name in tables_name_list ]
+        tables_ddls = [ get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag) for table_name in tables_name_list ]
+        table_ddls_str = ';\n'.join(tables_ddls) 
+        WriteToCloud(table_ddls_str, gcs_bucket, gcs_output_path, hive_database)
 
-        ddls_rdd = spark.sparkContext.parallelize(tables_ddls)
-        ddls_rdd.coalesce(1).saveAsTextFile(output_path)

--- a/python/dataproc_templates/hive/util/hive_ddl_extractor.py
+++ b/python/dataproc_templates/hive/util/hive_ddl_extractor.py
@@ -88,7 +88,6 @@ class HiveDDLExtractorTemplate(BaseTemplate):
                 f"{pprint.pformat(args)}"
             )
 
-
         def get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag):
             ddl_str = spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} {spark_tbls_opt}").rdd.map(lambda x: x[0]).collect()[0]
             ddl = (ddl_str if str(remove_location_flag).upper() != "TRUE" else ddl_str.split("\nLOCATION '")[0].split("\nUSING ")[0])+";"

--- a/python/dataproc_templates/hive/util/hive_ddl_extractor.py
+++ b/python/dataproc_templates/hive/util/hive_ddl_extractor.py
@@ -24,7 +24,6 @@ import dataproc_templates.util.template_constants as constants
 from dataproc_templates import BaseTemplate
 from pyspark.sql import SparkSession
 from datetime import datetime
-from google.cloud import storage
 
 class HiveDDLExtractorTemplate(BaseTemplate): 
     """
@@ -83,34 +82,23 @@ class HiveDDLExtractorTemplate(BaseTemplate):
         gcs_output_path: str = args[constants.HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH]
         spark_tbls_flag: bool = args[constants.HIVE_DDL_CONSIDER_SPARK_TABLES]
         remove_location_flag: bool = args[constants.HIVE_DDL_TRANSLATION_DISPOSITION]
-        gcs_bucket: str = gcs_output_path.split("gs://")[1].split("/")[0]
-        gcs_output_path: str = gcs_output_path.split("gs://")[1].split("/",maxsplit=1)[1]
 
         logger.info(
                 "Starting Hive DDL Extraction job with parameters:\n"
                 f"{pprint.pformat(args)}"
             )
-        
-        def WriteToCloud(ddl, bucket, path, hive_database):
-            """
-            Write String as a file to GCS
-            """
-            print("Writing DDL to GCS: " + hive_database)
-            client = storage.Client()
-            bucket = client.get_bucket(bucket)
-            blob = bucket.blob(path + "/" + hive_database + ".sql")
-            blob.upload_from_string(ddl)
 
 
         def get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag):
-            ddl_str = spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} {spark_tbls_opt}").rdd.map(lambda x: x[0] + ";").collect()[0]
+            ddl_str = spark.sql(f"SHOW CREATE TABLE {hive_database}.{table_name} {spark_tbls_opt}").rdd.map(lambda x: x[0]).collect()[0]
             ddl = ddl_str if str(remove_location_flag).upper() != "TRUE" else ddl_str.split("\nLOCATION '")[0].split("\nUSING ")[0]
-            return ddl
+            return ddl+";"
 
+        output_path = gcs_output_path+"/"+hive_database
         spark_tbls_opt = "" if str(spark_tbls_flag).upper() == "TRUE" else "AS SERDE"
         tables_names = spark.sql(f"SHOW TABLES IN {hive_database}").select("tableName")
         tables_name_list = tables_names.rdd.map(lambda x: x[0]).collect()
         tables_ddls = [ get_ddl(hive_database, table_name, spark_tbls_opt, remove_location_flag) for table_name in tables_name_list ]
-        table_ddls_str = ';\n'.join(tables_ddls) 
-        WriteToCloud(table_ddls_str, gcs_bucket, gcs_output_path, hive_database)
+        ddls_rdd = spark.sparkContext.parallelize(tables_ddls)
+        ddls_rdd.coalesce(1).saveAsTextFile(output_path)
 

--- a/python/dataproc_templates/util/template_constants.py
+++ b/python/dataproc_templates/util/template_constants.py
@@ -270,3 +270,5 @@ CASSANDRA_TO_GCS_QUERY = "cassandratogcs.input.query"
 # Hive DDL Extractor Util
 HIVE_DDL_EXTRACTOR_INPUT_DATABASE = "hive.ddl.extractor.input.database"
 HIVE_DDL_EXTRACTOR_OUTPUT_GCS_PATH = "hive.ddl.extractor.output.path"
+HIVE_DDL_CONSIDER_SPARK_TABLES = "hive.ddl.consider.spark.tables"
+HIVE_DDL_TRANSLATION_DISPOSITION = "hive.ddl.translation.disposition"

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,4 +5,3 @@ pytest>=7.1.1
 mock>=4.0.3
 pytest-cov>=3.0.0
 coverage>=6.3.2
-google-cloud-storage>=2.5.0

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,3 +5,4 @@ pytest>=7.1.1
 mock>=4.0.3
 pytest-cov>=3.0.0
 coverage>=6.3.2
+google-cloud-storage>=2.5.0

--- a/python/test/hive/util/test_hive_ddl_extractor.py
+++ b/python/test/hive/util/test_hive_ddl_extractor.py
@@ -20,6 +20,7 @@ import pyspark
 from dataproc_templates.hive.util.hive_ddl_extractor import \
     HiveDDLExtractorTemplate
 from datetime import datetime
+from google.cloud import storage
 
 class TestHiveDDLExtractorTemplate:
     """

--- a/python/test/hive/util/test_hive_ddl_extractor.py
+++ b/python/test/hive/util/test_hive_ddl_extractor.py
@@ -51,5 +51,4 @@ class TestHiveDDLExtractorTemplate:
         hive_ddl_extractor_template.run(mock_spark_session, mock_parsed_args)
         mock_spark_session.sql.assert_called_once_with("SHOW TABLES IN database")
         mock_spark_session.sparkContext.parallelize.assert_called_once_with([])
-        ct = datetime.now().strftime("%m-%d-%Y %H.%M.%S")
-        mock_spark_session.rdd.RDD.coalesce().saveAsTextFile.assert_called_once_with("gs://bucket/path/database/{ct}".format(ct=ct))
+        mock_spark_session.rdd.RDD.coalesce().saveAsTextFile.assert_called_once_with("gs://bucket/path/database")


### PR DESCRIPTION
Changes:
Added Optional Arguments:
 a. HIVE_DDL_CONSIDER_SPARK_TABLES: Will remove "AS SERDE" from the SQL if set to TRUE
 b. HIVE_DDL_TRANSLATION_DISPOSITION: Remove "LOCATION" parameter and "USING FORMAT" if set to TRUE
 
NOTE: using comes when it is a spark table and TRANSLATION API does not recognise it as a HIVE DDL
Example:
>>> spark.sql("show create table employees_partitioned").show(10,False)

|CREATE TABLE `default`.`employees_partitioned` (
  `eid` INT,
  `name` STRING,
  `position` STRING,
  `dept` STRING,
  `part1` INT,
  `part2` STRING)
USING text
PARTITIONED BY (part1, part2)
LOCATION 'hdfs://hive-cluster-m/user/hive/warehouse/partitiondb.db/employee'
TBLPROPERTIES (
  'transient_lastDdlTime' = '1670464514',
  'bucketing_version' = '2')
  
The above SQL gives error if supplied directly to the Translation API.