### PR TITLE
fix: add runtime_config_version to notebooks

### DIFF
--- a/notebooks/generic_notebook/vertex_pipeline_pyspark.ipynb
+++ b/notebooks/generic_notebook/vertex_pipeline_pyspark.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d2c62b00-03d1-4d9e-beb2-f9961452338a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -25,7 +29,11 @@
   {
    "cell_type": "markdown",
    "id": "6d7696ef-61d7-4c79-9eb2-281079b3802e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Run Dataproc Templates from Vertex AI Pipelines\n",
     "\n",
@@ -37,7 +45,11 @@
   {
    "cell_type": "markdown",
    "id": "bf94dbe6-3ea2-4e26-90db-0da6c5a008ab",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "\n",
@@ -53,7 +65,11 @@
   {
    "cell_type": "markdown",
    "id": "3cd82da5-c46e-4067-b810-93ede117cdda",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Permissions\n",
     "\n",
@@ -70,7 +86,11 @@
   {
    "cell_type": "markdown",
    "id": "6a2de52d-7099-4f03-becc-9886fa82b130",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Install the required packages"
    ]
@@ -79,7 +99,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b3742b9a-143d-49fc-b43c-e56179c7f0f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -91,7 +115,11 @@
   {
    "cell_type": "markdown",
    "id": "ed5cc9ee-1137-4fb9-9a7c-a49cd8bc1ae1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Once you've installed the additional packages, you need to restart the notebook kernel so it can find the packages."
    ]
@@ -100,7 +128,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "01c19b5e-e7d9-416f-ad12-edc19b6877e6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import os\n",
@@ -115,7 +147,11 @@
   {
    "cell_type": "markdown",
    "id": "4e1af72a-1fcc-4495-b710-58eb950a1d45",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Import dependencies"
    ]
@@ -124,7 +160,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c7aede36-3a0a-43f7-8e4c-db2d8087e289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import google.cloud.aiplatform as aiplatform\n",
@@ -137,7 +177,11 @@
   {
    "cell_type": "markdown",
    "id": "05c7aa35-f539-4f6a-a243-3e0799c47499",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Change working directory to the Dataproc Templates python folder"
    ]
@@ -146,7 +190,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d6e0e80a-e8b7-4e54-9f99-b7874e164978",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -164,7 +212,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "69752c22",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%cd $WORKING_DIRECTORY"
@@ -173,7 +225,11 @@
   {
    "cell_type": "markdown",
    "id": "e7dc50fd-c262-4308-804e-298e62af14b4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Set Google Cloud properties"
    ]
@@ -182,7 +238,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f010bef0-2d9f-430a-b89c-1875b1647c02",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "get_project_id = ! gcloud config list --format 'value(core.project)' 2>/dev/null\n",
@@ -196,7 +256,11 @@
   {
    "cell_type": "markdown",
    "id": "0ac30fae-1583-462e-a7a9-61f2736dbc5a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Build Dataproc Templates python package"
    ]
@@ -205,7 +269,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cfaa8c93-5e69-48fc-984a-f4fa3b28519b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PACKAGE_EGG_FILE = \"dist/dataproc_templates_distribution.egg\"\n",
@@ -215,7 +283,11 @@
   {
    "cell_type": "markdown",
    "id": "fe0f7ad9-7d01-4496-b08c-f9e69775d0c1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Copy package to the GCS bucket\n",
     "\n",
@@ -228,7 +300,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "261867cf-45fc-4940-8db8-e079edcf9cb3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "! gsutil cp main.py $GCS_STAGING_LOCATION/\n",
@@ -238,7 +314,11 @@
   {
    "cell_type": "markdown",
    "id": "07c6d386-e37e-4f7e-8376-f0f0ee6861a9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Set Dataproc Templates properties"
    ]
@@ -247,7 +327,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "63bc60ad-a0ab-4a0d-83ae-4f7af8a86498",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\"\n",
@@ -260,7 +344,11 @@
   {
    "cell_type": "markdown",
    "id": "5d33b841-0538-491f-b686-38ab4a01ad1e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Choose template and set template arguments"
    ]
@@ -268,7 +356,11 @@
   {
    "cell_type": "markdown",
    "id": "fc6dcb79-3a71-4cd5-a67e-1783d2456545",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "GCSTOBIGQUERY is chosen in this notebook as an example.  \n",
     "Check the arguments in the template's documentation.  "
@@ -278,7 +370,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "18574192-8d4d-43c8-98e5-f3d613c98fab",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "TEMPLATE_SPARK_ARGS = [\n",
@@ -294,7 +390,11 @@
   {
    "cell_type": "markdown",
    "id": "9896c320-f73e-40e8-9aab-cb519de241f3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Build pipeline and run Dataproc Template on Vertex AI Pipelines\n",
     "\n",
@@ -307,7 +407,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cfb58c14-c691-4e7f-982c-fb74f4820b59",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "aiplatform.init(project=PROJECT_ID, staging_bucket=GCS_STAGING_LOCATION)\n",
@@ -337,6 +441,7 @@
     "        python_file_uris=python_file_uris,\n",
     "        jar_file_uris=jar_file_uris,\n",
     "        subnetwork_uri=subnetwork_uri,\n",
+    "        runtime_config_version=\"1.1\", # issue 665\n",
     "        args=args,\n",
     "    )\n",
     "\n",

--- a/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
+++ b/notebooks/hive2bq/HiveToBigquery_notebook.ipynb
@@ -4,7 +4,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a3f55fbb-2197-4038-88c5-6c896a9f071a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -25,7 +29,11 @@
   {
    "cell_type": "markdown",
    "id": "fb9eff8d-6b63-4e8f-b369-68cbb4ef04ee",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "\n",
@@ -41,7 +49,11 @@
   {
    "cell_type": "markdown",
    "id": "0852a764-dad3-4f3b-b0b5-a71825469fd3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Permissions\n",
     "\n",
@@ -59,7 +71,10 @@
    "cell_type": "markdown",
    "id": "c640fa29-1a04-4301-974d-9fcec95b7e7c",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "#### Step 1:\n",
@@ -71,7 +86,10 @@
    "execution_count": null,
    "id": "b3742b9a-143d-49fc-b43c-e56179c7f0f2",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -87,7 +105,11 @@
   {
    "cell_type": "markdown",
    "id": "58552a67-9012-4ba9-82e9-d34299cd6d15",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -98,7 +120,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "01c19b5e-e7d9-416f-ad12-edc19b6877e6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -112,7 +138,11 @@
   {
    "cell_type": "markdown",
    "id": "7a2fa95e-b745-4649-8040-af99e7a4013c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 2:\n",
     "#### Set Google Cloud properties"
@@ -121,7 +151,11 @@
   {
    "cell_type": "markdown",
    "id": "920dd937-7a43-4709-8297-f9c346d7897c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Overview**  \n",
     "This notebook shows how to build a Vertex AI Pipeline to run a Dataproc Template   \n",
@@ -132,7 +166,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7e2ef85e-4cac-464c-9ed4-a66ea9c4f4c6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# User Configuration\n",
@@ -157,7 +195,11 @@
   {
    "cell_type": "markdown",
    "id": "454bb0de-3e0a-4daa-92ed-1319e1d9604d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 3:\n",
     "#### Import dependencies"
@@ -167,7 +209,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c7aede36-3a0a-43f7-8e4c-db2d8087e289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import google.cloud.aiplatform as aiplatform\n",
@@ -185,7 +231,11 @@
   {
    "cell_type": "markdown",
    "id": "d8b33331-b529-47ac-a08d-0c166acd264e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 4:\n",
     "#### Change working directory to the Dataproc Templates python folder"
@@ -195,7 +245,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da510653",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -213,7 +267,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d6e0e80a-e8b7-4e54-9f99-b7874e164978",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%cd $WORKING_DIRECTORY"
@@ -222,7 +280,11 @@
   {
    "cell_type": "markdown",
    "id": "e73bb252-c3e3-4d56-b1ad-f52a2db52869",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 5:\n",
     "#### Build Dataproc Templates python package"
@@ -233,7 +295,10 @@
    "execution_count": null,
    "id": "cfaa8c93-5e69-48fc-984a-f4fa3b28519b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -244,7 +309,11 @@
   {
    "cell_type": "markdown",
    "id": "b528c874-b948-40c1-b57c-afff76d80b47",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 6:\n",
     "#### Copy package to the GCS bucket\n",
@@ -258,7 +327,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "33dd85ce-46f6-4b35-8997-2189cf1b2eee",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "!gsutil cp main.py $GCS_STAGING_LOCATION/\n",
@@ -268,7 +341,11 @@
   {
    "cell_type": "markdown",
    "id": "5a8d8c5f-b28b-4fbb-b585-cb2f1d9c1915",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 7:\n",
     "#### Get Hive Tables \n",
@@ -281,7 +358,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3751abe3-47b7-4b4a-81f4-498da750d884",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "if INPUT_HIVE_TABLES==\"*\":\n",
@@ -307,7 +388,11 @@
   {
    "cell_type": "markdown",
    "id": "0dbaf266-91a0-46e2-8a88-b594b9301c83",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 8:\n",
     "\n",
@@ -318,7 +403,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6b170e58-7acf-4aae-9619-2361eef0ed12",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import copy\n",
@@ -341,7 +430,11 @@
   {
    "cell_type": "markdown",
    "id": "e7d5a0b9-d2b2-4072-aa4f-3748609f7cdc",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 9:\n",
     "\n",
@@ -352,7 +445,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "73197165-0ea0-4732-841d-8ba4bcd8a94d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\"\n",
@@ -365,7 +462,10 @@
    "cell_type": "markdown",
    "id": "332168ba-6e69-4f6e-aa03-38b4965b5304",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "#### Step 10:\n",
@@ -380,7 +480,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "095c13bf-c121-4465-88fc-04778ef35a36",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "runtime_prop={}\n",
@@ -422,6 +526,7 @@
     "                jar_file_uris=jar_file_uris,\n",
     "                subnetwork_uri=subnetwork_uri,\n",
     "                runtime_config_properties=runtime_prop,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS,\n",
     "            )\n",
     "            time.sleep(5)\n",
@@ -440,7 +545,11 @@
   {
    "cell_type": "markdown",
    "id": "a7ba4453-ddf9-4f35-901e-ab20433ae7fa",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Step 11:\n",
     "\n",
@@ -453,7 +562,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4580bcc2-9302-48dc-8a47-7ccac603fbd7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "AUDIT_DICT={}\n",
@@ -489,7 +602,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "28d5417b-ff58-492e-9957-356644627234",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/notebooks/mssql2bq/mssql-to-bigquery-notebook.ipynb
+++ b/notebooks/mssql2bq/mssql-to-bigquery-notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "e5876b8a-4fc8-43d5-93f6-fbd19fb2c433",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# MSSQL to BigQuery Migration"
    ]
@@ -12,7 +16,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f9a9e6d2-f721-48cc-a6a7-01787aa9362c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "79b8102d-df42-448a-9df4-35ae6b8fae07",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## References\n",
     "* [DataprocPySparkBatchOp reference](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.0/google_cloud_pipeline_components.experimental.dataproc.html) \n",
@@ -57,7 +69,11 @@
   {
    "cell_type": "markdown",
    "id": "5e06a8de-c8b0-4ada-81c7-54606c0afdb9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 1: Install Libraries\n",
     "<div class=\"alert alert-block alert-info\">\n",
@@ -68,7 +84,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "258dae17-19f2-410a-8cc9-f5980ccc30f4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "!pip3 install pymssql SQLAlchemy\n",
@@ -79,7 +99,11 @@
   {
    "cell_type": "markdown",
    "id": "d5a7126d-fc9c-4f04-8031-cbd835f891c6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -90,7 +114,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "74245439-10f3-4631-b8cd-4c077318b737",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -103,7 +131,11 @@
   {
    "cell_type": "markdown",
    "id": "50fe84b1-eb32-4cc2-a4e2-f0bd98da5b90",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 2: Import Libraries"
    ]
@@ -112,7 +144,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9f225135-cfe5-4ddd-9659-ead437aa414c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import google.cloud.aiplatform as aiplatform\n",
@@ -134,7 +170,11 @@
   {
    "cell_type": "markdown",
    "id": "af0cf264-6eef-441d-a0a4-0c7bdc3d5b96",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 3: Assign Parameters\n",
     "\n",
@@ -161,7 +201,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ee427d7c-edcb-46b2-a825-624db784aff0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PROJECT = \"<project-id>\"\n",
@@ -186,7 +230,11 @@
   {
    "cell_type": "markdown",
    "id": "f129a976-154d-4627-aa08-6430eac9b3fc",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 3.2 MSSQL Parameters\n",
     "\n",
@@ -212,7 +260,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e1aa479e-8318-4c5d-a36b-fdb497a6053a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQL_SERVER_HOST = \"<host-ip-address>\"\n",
@@ -227,7 +279,11 @@
   {
    "cell_type": "markdown",
    "id": "73cd7d7f-b70e-4f09-8b7d-c96038cc892c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 3.3 Notebook Configuration Parameters\n",
     "\n",
@@ -253,7 +309,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9f17741a-37e6-4657-bb3b-11b584270015",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQL_SERVER_DRIVER = \"mssql+pymssql\"\n",
@@ -268,7 +328,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6960dba0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -285,7 +349,11 @@
   {
    "cell_type": "markdown",
    "id": "d9323378-426e-4593-8b22-e6b20b64bfe9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 4: Generate SQL SERVER Table List\n",
     "\n",
@@ -302,7 +370,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "35d75bb9-8d10-4f0e-989b-8b81727ada7f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "if SQL_SERVER_SCHEMA_LIST and SQL_SERVER_TABLE_LIST:\n",
@@ -313,7 +385,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3f433106-453d-445f-bcda-8aad4efc0d95",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "DB = sqlalchemy.create_engine(\n",
@@ -349,7 +425,11 @@
   {
    "cell_type": "markdown",
    "id": "7359b268-ceec-4694-91ec-63f8469040dc",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 5: Get Primary Keys for partitioning the tables\n",
     "\n",
@@ -360,7 +440,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8346e717-5bd3-471f-938e-b64fc1721b3f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQL_TABLE_PRIMARY_KEYS = {}\n",
@@ -381,7 +465,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51baf6f6-2c68-4c63-adfd-f474aea6c48e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pkDF = pd.DataFrame({\"table\" : SQL_SERVER_TABLE_LIST, \"primary_keys\": list(SQL_TABLE_PRIMARY_KEYS.values())})\n",
@@ -392,7 +480,11 @@
   {
    "cell_type": "markdown",
    "id": "ba873f01-cda3-4954-aac6-6ddf7df54642",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 6: Create JAR files and Upload to GCS\n",
     "<div class=\"alert alert-block alert-info\">\n",
@@ -403,7 +495,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7603c8f5-0dbd-4fac-abcd-e6df133133f6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%cd $WORKING_DIRECTORY"
@@ -412,7 +508,11 @@
   {
    "cell_type": "markdown",
    "id": "4d6bed57-868d-4f87-8311-33359004d0a0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Get JDBC Connector jars"
    ]
@@ -421,7 +521,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b95e378d-1da3-4c61-a671-f1d8b9c53d65",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -434,7 +538,11 @@
   {
    "cell_type": "markdown",
    "id": "7ca2ab48-638d-41bb-a29a-4361fcc0a138",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Build Dataproc Templates python package"
    ]
@@ -443,7 +551,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2965a564-9a68-4092-82bc-904661ba01e4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "! python ./setup.py bdist_egg --output=$PACKAGE_EGG_FILE"
@@ -452,7 +564,11 @@
   {
    "cell_type": "markdown",
    "id": "fab7c84b-a310-4c77-ae96-0a444a989e67",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Copying JAR files to GCS_STAGING_LOCATION"
    ]
@@ -461,7 +577,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6c70baf3-2b11-4f84-b948-1ea70fb932ff",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "! gsutil cp main.py $GCS_STAGING_LOCATION/\n",
@@ -473,7 +593,11 @@
   {
    "cell_type": "markdown",
    "id": "53007b43-28c7-41db-8698-e70f4a84b8ea",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 7: Calculate Parallel Jobs for MSSQL to BigQuery\n",
     "\n",
@@ -484,7 +608,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "365e3ca3-4381-4191-b8ee-43659ba85940",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# calculate parallel jobs:\n",
@@ -507,7 +635,11 @@
   {
    "cell_type": "markdown",
    "id": "57e663cc-a269-4beb-87e1-740f772e9eb4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 8: Get Row Count of Tables and identify Partition Columns\n",
     "\n",
@@ -519,7 +651,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "636b871e-c975-4a0b-bc51-7069ce77e51e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PARTITION_THRESHOLD = 1000000\n",
@@ -530,7 +666,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f2055755-60ad-4371-a936-bfbfa8aaedb8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "with DB.connect() as conn:\n",
@@ -553,7 +693,11 @@
   {
    "cell_type": "markdown",
    "id": "ff7d7523-4f87-48e7-bbe5-d1206b817c3d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 9: Execute Pipeline to Migrate tables from MSSQL to BIGQUERY\n",
     "\n",
@@ -568,7 +712,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "46e607f2-c6c0-4abe-b4ff-ce34c83fcbf2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "BIGQUERY_DATASET=\"<bq-dataset>\"\n",
@@ -582,7 +730,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5f287fa2-8136-4c2b-a4ff-12cce31aa0dd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def migrate_mssql_to_bigquery(EXECUTION_LIST):\n",
@@ -641,6 +793,7 @@
     "                python_file_uris=PYTHON_FILE_URIS,\n",
     "                subnetwork_uri=SUBNETWORK_URI,\n",
     "                service_account=SERVICE_ACCOUNT,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS\n",
     "                )\n",
     "            time.sleep(3)\n",
@@ -660,7 +813,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1b1511c7-b899-4862-9e27-11071167febf",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "for execution_list in JOB_LIST:\n",
@@ -671,7 +828,11 @@
   {
    "cell_type": "markdown",
    "id": "23abfd4b-3658-4108-a28a-43d9adc28fe7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 10: Get status for tables migrated from SQL Server to BIGQUERY"
    ]
@@ -680,7 +841,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "35b11938-7875-4c15-acf4-111f7b15b3f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def get_bearer_token():\n",
@@ -709,7 +874,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "34feb439-3081-4719-90cd-320994b1422b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from google.auth.transport import requests\n",
@@ -727,7 +896,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1ffebab-b7fc-4456-a9f6-487a7b9fb18b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import requests\n",
@@ -749,7 +922,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6f63b7e2-ef71-4dda-a7bd-d421390f00ea",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "statusDF = pd.DataFrame({\"table\" : SQL_SERVER_TABLE_LIST,\"mssql_to_bigquery_job\" : MSSQL_TO_BIGQUERY_JOBS, \"mssql_to_bigquery_status\" : mssql_to_bigquery_status})\n",
@@ -759,7 +936,11 @@
   {
    "cell_type": "markdown",
    "id": "bd34e553-e49c-4848-8a46-df565cb5267f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 11: Validate row counts of migrated tables from SQL Server to BigQuery"
    ]
@@ -768,7 +949,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98ec2df4-a190-4e41-9c3e-d1f59cfb76e5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "mssql_row_count = []\n",
@@ -779,7 +964,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "617c5fa1-f3a2-4322-b3e9-d71e34e9e4de",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# get mssql table counts\n",
@@ -804,7 +993,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3d1f4420-cd44-4e77-9df7-11bff3733eed",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from google.cloud import bigquery\n",
@@ -822,7 +1015,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "412c823f-f574-47d3-b4c6-094858763926",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "statusDF['mssql_row_count'] = mssql_row_count \n",
@@ -834,7 +1031,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "566836ff-5cbb-4fcf-8fca-a7f00ef97139",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/notebooks/mssql2postgresql/mssql-to-postgres-notebook.ipynb
+++ b/notebooks/mssql2postgresql/mssql-to-postgres-notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "1f4d4022-15d2-4171-9460-425dcd7d9334",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# MSSQL to PostgreSQL Migration"
    ]
@@ -12,7 +16,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a5baf865-b719-4c0f-bc2c-4ac062cd7927",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "f4e7cc8e-c949-4d7d-a9f8-1ecd0d827f4b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "- [DataprocPySparkBatchOp reference](https://google-cloud-pipeline-components.readthedocs.io/en/google-cloud-pipeline-components-1.0.0/google_cloud_pipeline_components.experimental.dataproc.html)\n",
@@ -56,7 +68,11 @@
   {
    "cell_type": "markdown",
    "id": "9c27acdd-4438-4000-9b45-8b79a8805e87",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Contact\n",
     "Share you feedback, ideas, thoughts [feedback-form](https://forms.gle/XXCJeWeCJJ9fNLQS6)  \n",
@@ -67,7 +83,10 @@
    "cell_type": "markdown",
    "id": "31512ac6-a760-4f95-bb17-e5fc81b7d995",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Step 1: Install Libraries\n",
@@ -78,7 +97,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1feb899d-ea30-4ae5-9e19-3d3c85d5b663",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "!pip3 install pymssql SQLAlchemy\n",
@@ -89,7 +112,11 @@
   {
    "cell_type": "markdown",
    "id": "46a06f58-2c6e-4350-962c-9c398f0a31f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -100,7 +127,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4dc31237-ea30-475e-8254-b62765fec009",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -113,7 +144,11 @@
   {
    "cell_type": "markdown",
    "id": "84557378-e132-4cf1-9a05-a2c18d65d404",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 2: Import Libraries"
    ]
@@ -122,7 +157,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7f7649c8-a118-42d4-b385-c49be2cc1070",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import google.cloud.aiplatform as aiplatform\n",
@@ -145,7 +184,10 @@
    "cell_type": "markdown",
    "id": "abd3ac39-28ab-4339-8865-0a7024963bc6",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Step 3: Assign Parameters"
@@ -154,7 +196,11 @@
   {
    "cell_type": "markdown",
    "id": "03c17a10-6166-4c6b-9297-127dcbb8c1be",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.1 Common Parameters\n",
     "##### PROJECT : GCP project-id\n",
@@ -169,7 +215,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "821480e9-c9a1-42eb-9604-dc33c5881689",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Get GCP Project\n",
@@ -184,7 +234,11 @@
   {
    "cell_type": "markdown",
    "id": "66d0d0a9-5556-494d-bde4-0e9998795e5f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.2 MSSQL Parameters\n",
     "#### MSSQL_HOST : MSSQL instance ip address\n",
@@ -200,7 +254,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dacdf900-5609-45ba-81cc-cfa5d27685ed",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "MSSQL_HOST=\"<host>\"\n",
@@ -215,7 +273,10 @@
    "cell_type": "markdown",
    "id": "2e01a00f-0c36-44f1-93bd-d849c62d5bac",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "### Step 3.3 PostgreSQL Parameters\n",
@@ -232,7 +293,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "35947f0a-860a-46c0-b89e-6be99dea113c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "POSTGRES_HOST=\"<host>\"\n",
@@ -247,7 +312,11 @@
   {
    "cell_type": "markdown",
    "id": "ba335fa7-d46f-4253-bc7f-b0cb5c303592",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.4 Notebook Configuration Parameters\n",
     "#### Below variables shoulld not be changed unless required"
@@ -257,7 +326,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f204af9b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -275,7 +348,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "34123cf3-4ce0-49c6-b7b9-ed40f4fb199f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PYMSSQL_DRIVER=\"mssql+pymssql\"\n",
@@ -297,7 +374,11 @@
   {
    "cell_type": "markdown",
    "id": "3ca6ce4f-cfd2-4726-8e80-9cb059a05550",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 4: Generate MSSQL Table List\n",
     "This step creates list of tables for migration. If MSSQLTABLE_LIST is kept empty all the tables in the MSSQL_DATABASE are listed for migration otherwise the provided list is used"
@@ -307,7 +388,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3a7a89ee-7500-4ad1-b444-0971b40599f5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQLTABLE_LIST=MSSQLTABLE_LIST\n",
@@ -336,7 +421,11 @@
   {
    "cell_type": "markdown",
    "id": "dd9304c2-e713-482a-aa9e-ddc97578b98b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 5: Get Primary Keys for partition the tables\n",
     "This step fetches primary key from MSSQL_DATABASE for the tables listed for migration"
@@ -346,7 +435,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3ab28c89-4c2f-486e-9d7b-edfc89f0d5d0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQL_TABLE_PRIMARY_KEYS = {}\n",
@@ -378,7 +471,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "59679f52-0774-4cd6-8822-b6e80fb08224",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pkDF = pd.DataFrame({\"table\" : SQLTABLE_LIST, \"primary_keys\": list(SQL_TABLE_PRIMARY_KEYS.values())})\n",
@@ -389,7 +486,11 @@
   {
    "cell_type": "markdown",
    "id": "363d46ea-d3a7-4e52-b527-21bee93fd305",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 6: Create JAR files and Upload to GCS\n",
     "#### Run Step 6 one time for each new notebook instance"
@@ -399,7 +500,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b3742b9a-143d-49fc-b43c-e56179c7f0f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%cd $WORKING_DIRECTORY"
@@ -408,7 +513,11 @@
   {
    "cell_type": "markdown",
    "id": "c4087b4b-c5be-407d-b2bd-e5d6da5a0222",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Get JDBC Connector jars"
    ]
@@ -417,7 +526,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a0fa7572-0a4b-49c7-9359-cf3ce4514b48",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -428,7 +541,11 @@
   {
    "cell_type": "markdown",
    "id": "9e141fde-4e48-4953-833b-176e255037c9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Build Dataproc Templates python package"
    ]
@@ -437,7 +554,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6f399004-26bf-480a-9640-5cfb97994f4c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "! python ./setup.py bdist_egg --output=$PACKAGE_EGG_FILE"
@@ -446,7 +567,11 @@
   {
    "cell_type": "markdown",
    "id": "5bea938a-1951-44d4-a18b-063b9d7c8bd4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Copying JAR files to GCS_STAGING_LOCATION"
    ]
@@ -455,7 +580,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "33dd85ce-46f6-4b35-8997-2189cf1b2eee",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "! gsutil cp main.py $GCS_STAGING_LOCATION/\n",
@@ -467,7 +596,11 @@
   {
    "cell_type": "markdown",
    "id": "cf52c73c-ad16-4932-a421-349f5f718df2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 7: Calculate Parallel Jobs for MSSQL to PostgreSQL\n",
     "This step uses MAX_PARALLELISM parameter to calculate number of parallel jobs to run"
@@ -477,7 +610,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8bc06aa-298b-4d1f-9822-62264371a681",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "COMPLETE_LIST = copy.deepcopy(SQLTABLE_LIST)\n",
@@ -499,7 +636,11 @@
   {
    "cell_type": "markdown",
    "id": "84fd6c0e-9128-4981-916e-f774e40f9120",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 8: Get Row Count of Tables and identify Partition Columns \n",
     "#### This step uses PARTITION_THRESHOLD(default value is 1 million) parameter and any table having rows greater than PARTITION_THRESHOLD will be partitioned based on Primary Keys\n",
@@ -510,7 +651,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bfa2bacc-b3b0-43f0-8825-8744010a25b2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PARTITION_THRESHOLD=1000000 #\"Maximum Row Count Threshold for a Table\"\n",
@@ -523,7 +668,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f9725435-79c2-4b40-9aa7-e64e7440fb88",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "with DB.connect() as conn:\n",
@@ -546,7 +695,11 @@
   {
    "cell_type": "markdown",
    "id": "cae5f3ed-8ba4-4801-bb31-296221d64578",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 9:Create Source Schemas in PostgreSQL"
    ]
@@ -555,7 +708,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ad52bc86-1c77-4138-ab58-f849226b4137",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import psycopg2\n",
@@ -578,7 +735,11 @@
   {
    "cell_type": "markdown",
    "id": "11fce10a-6d1e-4fd6-b1f6-9175680614dd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 10: Execute Pipeline to Migrate tables from MSSQL to PostgreSQL"
    ]
@@ -587,7 +748,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "37abf9cd-d4df-4760-8dda-351ede03bf10",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def migrate_mssql_to_postgres(EXECUTION_LIST):\n",
@@ -650,6 +815,7 @@
     "                jar_file_uris=JAR_FILE_URIS,\n",
     "                python_file_uris=PYTHON_FILE_URIS,\n",
     "                subnetwork_uri=SUBNETWORK_URI,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS\n",
     "                )\n",
     "            time.sleep(3)\n",
@@ -669,7 +835,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "18574192-8d4d-43c8-98e5-f3d613c98fab",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "for execution_list in JOB_LIST:\n",
@@ -680,7 +850,11 @@
   {
    "cell_type": "markdown",
    "id": "fb06f8bc-ef97-4665-8a5d-71e195c0d85d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 11: Get status for tables migrated from MSSQL to PostgreSQL"
    ]
@@ -689,7 +863,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "136f4298-d5fd-4d3b-9f9a-12ef82d35b97",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def get_bearer_token():\n",
@@ -718,7 +896,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2a5a8a6d-ca0b-4d1b-b325-f347b83f619d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from google.auth.transport import requests\n",
@@ -735,7 +917,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8dcbdd49-1125-446f-bfb4-52981fec44ea",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import requests\n",
@@ -757,7 +943,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dde0a504-0f21-466d-b63a-b5e760344e8a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "statusDF = pd.DataFrame({\"table\" : SQLTABLE_LIST,\"mssql_to_postgres_job\" : mssql_to_postgres_jobs, \"mssql_to_postgres_status\" : mssql_to_postgres_status})\n",
@@ -767,7 +957,11 @@
   {
    "cell_type": "markdown",
    "id": "1386d002-3dc6-4b88-9288-45958cfc7c7a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 12: Validate row counts of migrated tables from MSSQL to PostgreSQL"
    ]
@@ -776,7 +970,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c80e8290-0c41-4fbf-ad93-6ec04de5d0da",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "mssql_row_count = []\n",
@@ -787,7 +985,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ae6e1f5a-8e58-4998-b8c7-50d26ea1433e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# get mssql table counts\n",
@@ -812,7 +1014,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d2f7c149-df59-4df0-87ec-7a2058503bdd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import psycopg2\n",
@@ -838,7 +1044,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b48ac8aa-1843-4144-b6bc-6ab992b61ac9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "statusDF['mssql_row_count'] = mssql_row_count \n",

--- a/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
+++ b/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "1db5371a-8f16-47b7-bcc7-5af386e9b6d8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# <center>MySQL to Cloud Spanner Migration (or Bulk Load)"
    ]
@@ -12,7 +16,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98acd907",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "dd944742",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "\n",
@@ -60,7 +72,11 @@
   {
    "cell_type": "markdown",
    "id": "7d89b301-5249-462a-97d8-986488b303fd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 1: Install Libraries\n",
     "#### Run Step 1 one time for each new notebook instance"
@@ -71,7 +87,10 @@
    "execution_count": null,
    "id": "fef65ec2-ad6b-407f-a993-7cdf871bba11",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -84,7 +103,10 @@
    "execution_count": null,
    "id": "0e90943f-b965-4f7f-b631-ce62227d5e83",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -96,7 +118,11 @@
   {
    "cell_type": "markdown",
    "id": "35712473-92ef-433b-9ce6-b5649357c09e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -107,7 +133,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "19ef1307-902e-4713-8948-b86084e19312",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -120,7 +150,11 @@
   {
    "cell_type": "markdown",
    "id": "70d01e33-9099-4d2e-b57e-575c3a998d84",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 2: Import Libraries"
    ]
@@ -130,7 +164,10 @@
    "execution_count": null,
    "id": "2703b502-1b41-44f1-bf21-41069255bc32",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -153,7 +190,11 @@
   {
    "cell_type": "markdown",
    "id": "09c4a209-db59-42f6-bba7-30cd46b16bad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 3: Assign Parameters"
    ]
@@ -161,7 +202,11 @@
   {
    "cell_type": "markdown",
    "id": "92d3fbd8-013f-45e6-b7e9-8f31a4580e91",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.1 Common Parameters\n",
     " \n",
@@ -178,7 +223,10 @@
    "execution_count": null,
    "id": "bd8f6dd9-2e13-447c-b28d-10fa2321b759",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -195,7 +243,11 @@
   {
    "cell_type": "markdown",
    "id": "051df2af-bd8b-47c7-8cb2-05404ca0d859",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.2 MYSQL to Spanner Parameters\n",
     "- MYSQL_HOST : MYSQL instance ip address\n",
@@ -217,7 +269,10 @@
    "execution_count": null,
    "id": "71dd2824-e9a0-4ceb-a3c9-32f79973432a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -236,7 +291,11 @@
   {
    "cell_type": "markdown",
    "id": "166b1536-d58e-423b-b3c2-cc0c171d275e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.3 Notebook Configuration Parameters\n",
     "Below variables shoulld not be changed unless required"
@@ -246,7 +305,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "367f66b6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -265,7 +328,10 @@
    "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -288,7 +354,11 @@
   {
    "cell_type": "markdown",
    "id": "115c062b-5a91-4372-b440-5c37a12fbf87",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 4: Generate MySQL Table List\n",
     "This step creates list of tables for migration. If MYSQLTABLE_LIST is kept empty all the tables in the MYSQL_DATABASE are listed for migration otherwise the provided list is used"
@@ -299,7 +369,10 @@
    "execution_count": null,
    "id": "d0e362ac-30cd-4857-9e2a-0e9eb926e627",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -328,7 +401,11 @@
   {
    "cell_type": "markdown",
    "id": "1d9a62e8-7499-41c6-b32b-73b539b0c7c4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 5: Get Primary Keys for tables not present in SPANNER_TABLE_PRIMARY_KEYS\n",
     "For tables which do not have primary key provided in dictionary SPANNER_TABLE_PRIMARY_KEYS this step fetches primary key from MYSQL_DATABASE"
@@ -339,7 +416,10 @@
    "execution_count": null,
    "id": "6eda8fac-582c-4d4a-b871-311bb2863335",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -371,7 +451,10 @@
    "execution_count": null,
    "id": "7c2a210f-48da-474f-bf46-89e755d01c67",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -383,7 +466,11 @@
   {
    "cell_type": "markdown",
    "id": "02748c28-54e9-466c-9537-c00569122a96",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 6 Get Row Count of Tables and identify read partition column\n",
     "This step uses PARTITION_THRESHOLD(default value is 1 million) parameter and any table having rows greater than PARTITION_THRESHOLD will be partitioned based on Primary Key\n",
@@ -395,7 +482,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b4e4f6e9-c559-48e8-95fd-d2dd3e173439",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PARTITION_THRESHOLD = 200000 #Number of rows fetched per spark executor\n",
@@ -406,7 +497,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eb9f5487-bb82-4261-87ad-0a938e9df076",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "with DB.connect() as conn:\n",
@@ -435,7 +530,11 @@
   {
    "cell_type": "markdown",
    "id": "0d9bb170-09c4-40d1-baaf-9e907f215889",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 7: Calculate Parallel Jobs for MySQL to Cloud Spanner\n",
     "This step uses MAX_PARALLELISM parameter to calculate number of parallel jobs to run"
@@ -446,7 +545,10 @@
    "execution_count": null,
    "id": "2c501db0-c1fb-4a05-88b8-a7e546e2b1d0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -470,7 +572,11 @@
   {
    "cell_type": "markdown",
    "id": "1fa5f841-a687-4723-a8e6-6e7e752ba36e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 8: Create JAR files and Upload to GCS\n",
     "#### Run Step 8 one time for each new notebook instance"
@@ -481,7 +587,10 @@
    "execution_count": null,
    "id": "22220ae3-9fb4-471c-b5aa-f606deeca15e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -491,7 +600,11 @@
   {
    "cell_type": "markdown",
    "id": "bdee7afc-699b-4c1a-aeec-df0f99764ae0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Setting PATH variables for JDK and Maven and executing MAVEN build"
    ]
@@ -501,7 +614,10 @@
    "execution_count": null,
    "id": "4b40f634-1983-4267-a4c1-b072bf6d81ae",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -514,7 +630,11 @@
   {
    "cell_type": "markdown",
    "id": "9e1a779f-2c39-42ec-98be-0f5e9d715447",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### copying JARS files to GCS_STAGING_LOCATION"
    ]
@@ -524,7 +644,10 @@
    "execution_count": null,
    "id": "939cdcd5-0f3e-4f51-aa78-93d1976cb0f4",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -537,7 +660,11 @@
   {
    "cell_type": "markdown",
    "id": "78f6f83b-891a-4515-a1d6-f3406a25dc2a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 9: Execute Pipeline to Migrate tables from MySQL to Spanner"
    ]
@@ -547,7 +674,10 @@
    "execution_count": null,
    "id": "b51912cd-17cb-4607-a1e3-9a4a599cd611",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -558,7 +688,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "11e8a699-317d-46df-a4b1-7132e14ccdf4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def migrate_mysql_to_spanner(EXECUTION_LIST):\n",
@@ -620,6 +754,7 @@
     "                jar_file_uris=JAR_FILE_URIS,\n",
     "                file_uris=FILE_URIS,\n",
     "                subnetwork_uri=SUBNETWORK_URI,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS\n",
     "            )\n",
     "            time.sleep(1)\n",
@@ -640,7 +775,10 @@
    "execution_count": null,
    "id": "e696ce34-b5a3-4f5d-98a7-ac881007c6c5",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -652,7 +790,11 @@
   {
    "cell_type": "markdown",
    "id": "9ce7f828-dacc-404b-8927-dc3813e7216a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 10: Get status for tables migrated from MySql to Spanner"
    ]
@@ -662,7 +804,10 @@
    "execution_count": null,
    "id": "c282b2b9-b126-4cb6-a513-14a6322650c0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -693,7 +838,10 @@
    "execution_count": null,
    "id": "d1fcbc63-19db-42a8-a2ed-d9855da00c04",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -711,7 +859,10 @@
    "execution_count": null,
    "id": "5be3cf87-6d28-4b23-8466-87d3399f7a29",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -735,7 +886,10 @@
    "execution_count": null,
    "id": "1097575d-07c2-4659-a75f-d7e898e3f077",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -746,7 +900,11 @@
   {
    "cell_type": "markdown",
    "id": "0961f164-c7e4-4bb5-80f0-25fd1051147b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 11: Validate row counts of migrated tables from MySQL to Cloud Spanner"
    ]
@@ -756,7 +914,10 @@
    "execution_count": null,
    "id": "25299344-c167-4764-a5d1-56c1b384d104",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -784,7 +945,10 @@
    "execution_count": null,
    "id": "ab0e539d-5180-4f5b-915e-35f7ea45e0d3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -809,7 +973,10 @@
    "execution_count": null,
    "id": "4b1afe12-3eb9-4133-8377-66dc63ac649c",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -821,7 +988,11 @@
   {
    "cell_type": "markdown",
    "id": "9f30ffe4-efb5-4b84-b364-c40a296e95f7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Post data loading activities\n",
     "- You may create relationships (FKs), constraints and indexes (as needed).\n",
@@ -832,7 +1003,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "89ec62c1-0b95-4536-9339-03a4a8de035e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
+++ b/notebooks/oracle2bq/OracleToBigQuery_notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "1db5371a-8f16-47b7-bcc7-5af386e9b6d8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# <center>Oracle to BigQuery"
    ]
@@ -12,7 +16,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98acd907",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "dd944742",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "\n",
@@ -66,7 +78,11 @@
   {
    "cell_type": "markdown",
    "id": "7d89b301-5249-462a-97d8-986488b303fd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 1: Install Libraries\n",
     "#### Run Step 1 one time for each new notebook instance"
@@ -77,7 +93,10 @@
    "execution_count": null,
    "id": "fef65ec2-ad6b-407f-a993-7cdf871bba11",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -89,7 +108,11 @@
   {
    "cell_type": "markdown",
    "id": "2fe7de03-566e-4902-97e9-eb9c9c4a8d8f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Oracle client Installation"
    ]
@@ -100,7 +123,10 @@
    "id": "82bc9e6c-408e-4e87-9e44-82dff4f97969",
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -122,7 +148,11 @@
   {
    "cell_type": "markdown",
    "id": "31456ac6-d058-4d90-8b18-c10f92922f81",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -133,7 +163,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "19ef1307-902e-4713-8948-b86084e19312",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -146,7 +180,11 @@
   {
    "cell_type": "markdown",
    "id": "70d01e33-9099-4d2e-b57e-575c3a998d84",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 2: Import Libraries"
    ]
@@ -156,7 +194,10 @@
    "execution_count": null,
    "id": "2703b502-1b41-44f1-bf21-41069255bc32",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -178,7 +219,11 @@
   {
    "cell_type": "markdown",
    "id": "09c4a209-db59-42f6-bba7-30cd46b16bad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 3: Assign Parameters"
    ]
@@ -186,7 +231,11 @@
   {
    "cell_type": "markdown",
    "id": "92d3fbd8-013f-45e6-b7e9-8f31a4580e91",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.1 Common Parameters\n",
     " \n",
@@ -204,7 +253,10 @@
    "execution_count": null,
    "id": "abe19575-7914-4dfa-b496-b8b2cfe2afd6",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -223,7 +275,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4a87c4e3-a4bd-44bd-8120-99097383bcec",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# If SERVICE_ACCOUNT is not specified it will take the one attached to Notebook\n",
@@ -236,7 +292,11 @@
   {
    "cell_type": "markdown",
    "id": "051df2af-bd8b-47c7-8cb2-05404ca0d859",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.2 ORACLE to BIGQUERY Parameters\n",
     "- ORACLE_HOST : Oracle instance ip address\n",
@@ -252,7 +312,10 @@
    "execution_count": null,
    "id": "a4c61a12-7f39-41df-ace8-5d5c573680f1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -267,7 +330,11 @@
   {
    "cell_type": "markdown",
    "id": "166b1536-d58e-423b-b3c2-cc0c171d275e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.3 Notebook Configuration Parameters\n",
     "Below variables should not be changed unless required\n",
@@ -286,7 +353,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8fa610c5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -305,7 +376,10 @@
    "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -322,7 +396,11 @@
   {
    "cell_type": "markdown",
    "id": "115c062b-5a91-4372-b440-5c37a12fbf87",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 4: Generate ORACLE Table List\n",
     "This step creates list of tables for migration. If ORACLETABLE_LIST is kept empty all the tables in the ORACLE_DATABASE are listed for migration otherwise the provided list is used"
@@ -333,7 +411,10 @@
    "execution_count": null,
    "id": "d0e362ac-30cd-4857-9e2a-0e9eb926e627",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -353,7 +434,11 @@
   {
    "cell_type": "markdown",
    "id": "1d9a62e8-7499-41c6-b32b-73b539b0c7c4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 5: Get Primary Keys for tables from ORACLE source\n",
     "This step fetches primary key of tables listed in ORACLETABLE_LIST from ORACLE_DATABASE"
@@ -363,7 +448,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e7b9074c-a38e-4261-ae4e-57a498aaec88",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SQL_TABLE_PRIMARY_KEYS = {} #dict for storing primary keys for each table"
@@ -374,7 +463,10 @@
    "execution_count": null,
    "id": "6eda8fac-582c-4d4a-b871-311bb2863335",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -396,7 +488,10 @@
    "execution_count": null,
    "id": "7c2a210f-48da-474f-bf46-89e755d01c67",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -408,7 +503,11 @@
   {
    "cell_type": "markdown",
    "id": "f8ac9a9f-1332-4c75-b6ca-bfb3b776671f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 6: Get Row Count of Tables and identify Partition Columns\n",
     "This step uses PARTITION_THRESHOLD(default value is 1 million) parameter and any table having rows greater than PARTITION_THRESHOLD will be used for partitioned read based on Primary Keys\n",
@@ -419,7 +518,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fe54e83c-7845-4043-baf8-c0ee6f32787a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PARTITION_THRESHOLD = 1000000\n",
@@ -430,7 +533,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b692a051-7555-42fc-af27-b05e461576f4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "with DB.connect() as conn:\n",
@@ -452,7 +559,11 @@
   {
    "cell_type": "markdown",
    "id": "1fa5f841-a687-4723-a8e6-6e7e752ba36e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 7: Download JAR files and Upload to GCS (only rquired to run one-time)\n",
     "#### Run Step 7 one time for each new notebook instance"
@@ -463,7 +574,10 @@
    "execution_count": null,
    "id": "22220ae3-9fb4-471c-b5aa-f606deeca15e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -473,7 +587,11 @@
   {
    "cell_type": "markdown",
    "id": "bdee7afc-699b-4c1a-aeec-df0f99764ae0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Downloading JDBC Oracle Driver and Bigquery Spark Connector Jar files"
    ]
@@ -484,7 +602,10 @@
    "id": "4b40f634-1983-4267-a4c1-b072bf6d81ae",
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -499,7 +620,10 @@
    "id": "06735281-1c22-48d3-9b71-20f9ca99d04a",
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -509,7 +633,11 @@
   {
    "cell_type": "markdown",
    "id": "9e1a779f-2c39-42ec-98be-0f5e9d715447",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Copying JARS files to GCS_STAGING_LOCATION"
    ]
@@ -519,7 +647,10 @@
    "execution_count": null,
    "id": "939cdcd5-0f3e-4f51-aa78-93d1976cb0f4",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -532,7 +663,11 @@
   {
    "cell_type": "markdown",
    "id": "0d9bb170-09c4-40d1-baaf-9e907f215889",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 8: Calculate Parallel Jobs for ORACLE to BIGQUERY\n",
     "This step uses MAX_PARALLELISM parameter to calculate number of parallel jobs to run"
@@ -543,7 +678,10 @@
    "execution_count": null,
    "id": "2c501db0-c1fb-4a05-88b8-a7e546e2b1d0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -567,7 +705,11 @@
   {
    "cell_type": "markdown",
    "id": "78f6f83b-891a-4515-a1d6-f3406a25dc2a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 9: Execute Pipeline to Migrate tables from ORACLE to BIGQUERY\n",
     "- BIGQUERY_DATASET : Target dataset in Bigquery\n",
@@ -582,7 +724,10 @@
    "execution_count": null,
    "id": "1f98914b-bd74-4d0e-9562-7019d504a25e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -599,7 +744,10 @@
    "execution_count": null,
    "id": "22f7d00c-bd2a-4aaa-aee4-e41a9793dfb1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -663,6 +811,7 @@
     "                python_file_uris=PYTHON_FILE_URIS,\n",
     "                subnetwork_uri=SUBNETWORK_URI,\n",
     "                service_account=SERVICE_ACCOUNT,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS\n",
     "                )\n",
     "            time.sleep(3)\n",
@@ -684,7 +833,10 @@
    "id": "44205b54-1ac7-42f3-85ad-5b20f531056b",
    "metadata": {
     "scrolled": true,
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -696,7 +848,11 @@
   {
    "cell_type": "markdown",
    "id": "9ce7f828-dacc-404b-8927-dc3813e7216a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 10: Get status for tables migrated from ORACLE to BIGQUERY"
    ]
@@ -706,7 +862,10 @@
    "execution_count": null,
    "id": "b611510f-271c-447a-899d-42fbb983268d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -737,7 +896,10 @@
    "execution_count": null,
    "id": "d1fcbc63-19db-42a8-a2ed-d9855da00c04",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -755,7 +917,10 @@
    "execution_count": null,
    "id": "5be3cf87-6d28-4b23-8466-87d3399f7a29",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -779,7 +944,10 @@
    "execution_count": null,
    "id": "1097575d-07c2-4659-a75f-d7e898e3f077",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -790,7 +958,11 @@
   {
    "cell_type": "markdown",
    "id": "0961f164-c7e4-4bb5-80f0-25fd1051147b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 11: Validate row counts of migrated tables from ORACLE to BigQuery"
    ]
@@ -800,7 +972,10 @@
    "execution_count": null,
    "id": "8a3a28fb-3a39-4a10-b92d-0685b351a1b3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -813,7 +988,10 @@
    "execution_count": null,
    "id": "25299344-c167-4764-a5d1-56c1b384d104",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -831,7 +1009,10 @@
    "execution_count": null,
    "id": "ab0e539d-5180-4f5b-915e-35f7ea45e0d3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -851,7 +1032,10 @@
    "execution_count": null,
    "id": "4b1afe12-3eb9-4133-8377-66dc63ac649c",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -864,7 +1048,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "89232bc9-e0f6-4ab4-8524-343ea7562eb0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": []
   }

--- a/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
+++ b/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "1db5371a-8f16-47b7-bcc7-5af386e9b6d8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# <center>Oracle to Cloud Spanner"
    ]
@@ -12,7 +16,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "98acd907",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# Copyright 2022 Google LLC\n",
@@ -33,7 +41,11 @@
   {
    "cell_type": "markdown",
    "id": "dd944742",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### References\n",
     "\n",
@@ -66,7 +78,11 @@
   {
    "cell_type": "markdown",
    "id": "7d89b301-5249-462a-97d8-986488b303fd",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 1: Install Libraries\n",
     "#### Run Step 1 one time for each new notebook instance"
@@ -77,7 +93,10 @@
    "execution_count": null,
    "id": "fef65ec2-ad6b-407f-a993-7cdf871bba11",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -90,7 +109,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0ed8fb64-8bae-4ff4-9e87-fdcc8ee04bcf",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "!sudo apt-get update -y\n",
@@ -101,7 +124,11 @@
   {
    "cell_type": "markdown",
    "id": "f023c6c2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Oracle client Installation"
    ]
@@ -111,7 +138,10 @@
    "execution_count": null,
    "id": "0e90943f-b965-4f7f-b631-ce62227d5e83",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -133,7 +163,11 @@
   {
    "cell_type": "markdown",
    "id": "35712473-92ef-433b-9ce6-b5649357c09e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Once you've installed the additional packages, you may need to restart the notebook kernel so it can find the packages.\n",
     "\n",
@@ -144,7 +178,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "19ef1307-902e-4713-8948-b86084e19312",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# import os\n",
@@ -157,7 +195,11 @@
   {
    "cell_type": "markdown",
    "id": "70d01e33-9099-4d2e-b57e-575c3a998d84",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 2: Import Libraries"
    ]
@@ -167,7 +209,10 @@
    "execution_count": null,
    "id": "2703b502-1b41-44f1-bf21-41069255bc32",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -188,7 +233,11 @@
   {
    "cell_type": "markdown",
    "id": "09c4a209-db59-42f6-bba7-30cd46b16bad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 3: Assign Parameters"
    ]
@@ -196,7 +245,11 @@
   {
    "cell_type": "markdown",
    "id": "92d3fbd8-013f-45e6-b7e9-8f31a4580e91",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.1 Common Parameters\n",
     " \n",
@@ -214,7 +267,10 @@
    "execution_count": null,
    "id": "bd8f6dd9-2e13-447c-b28d-10fa2321b759",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -233,7 +289,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "128c08ea-67c2-4afb-b04f-33ec6351a7c7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# If SERVICE_ACCOUNT is not specified it will take the one attached to Notebook\n",
@@ -246,7 +306,11 @@
   {
    "cell_type": "markdown",
    "id": "051df2af-bd8b-47c7-8cb2-05404ca0d859",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.2 Oracle to Cloud Spanner Parameters\n",
     "- ORACLE_HOST : Oracle instance ip address\n",
@@ -266,7 +330,10 @@
    "execution_count": null,
    "id": "71dd2824-e9a0-4ceb-a3c9-32f79973432a",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -286,7 +353,11 @@
   {
    "cell_type": "markdown",
    "id": "166b1536-d58e-423b-b3c2-cc0c171d275e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Step 3.3 Notebook Configuration Parameters\n",
     "Below variables should not be changed unless required\n",
@@ -305,7 +376,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bcb42b2f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "cur_path = Path(os.getcwd())\n",
@@ -324,7 +399,10 @@
    "execution_count": null,
    "id": "c6f0f037-e888-4479-a143-f06a39bd5cc1",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -349,7 +427,11 @@
   {
    "cell_type": "markdown",
    "id": "115c062b-5a91-4372-b440-5c37a12fbf87",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 4: Generate ORACLE Table List\n",
     "This step creates list of tables for migration. If ORACLE_TABLE_LIST is kept empty all the tables in the ORACLE_DATABASE are listed for migration otherwise the provided list is used"
@@ -360,7 +442,10 @@
    "execution_count": null,
    "id": "d0e362ac-30cd-4857-9e2a-0e9eb926e627",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -380,7 +465,11 @@
   {
    "cell_type": "markdown",
    "id": "1d9a62e8-7499-41c6-b32b-73b539b0c7c4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 5: Get Primary Keys for tables not present in SPANNER_TABLE_PRIMARY_KEYS\n",
     "For tables which do not have primary key provided in dictionary SPANNER_TABLE_PRIMARY_KEYS this step fetches primary key from ORACLE_DATABASE"
@@ -391,7 +480,10 @@
    "execution_count": null,
    "id": "6eda8fac-582c-4d4a-b871-311bb2863335",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -414,7 +506,10 @@
    "execution_count": null,
    "id": "7c2a210f-48da-474f-bf46-89e755d01c67",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -426,7 +521,11 @@
   {
    "cell_type": "markdown",
    "id": "02748c28-54e9-466c-9537-c00569122a96",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Step 6: Get Row Count of Tables and identify Partition Columns\n",
     "This step uses PARTITION_THRESHOLD(default value is 1 million) parameter and any table having rows greater than PARTITION_THRESHOLD will be used for partitioned read based on Primary Keys\n",
@@ -437,7 +536,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b4e4f6e9-c559-48e8-95fd-d2dd3e173439",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "PARTITION_THRESHOLD = 1000000\n",
@@ -448,7 +551,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eb9f5487-bb82-4261-87ad-0a938e9df076",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "with DB.connect() as conn:\n",
@@ -471,7 +578,11 @@
   {
    "cell_type": "markdown",
    "id": "1fa5f841-a687-4723-a8e6-6e7e752ba36e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 7: Download JAR files and Upload to GCS (only required to run one-time)\n",
     "#### Run Step 7 one time for each new notebook instance"
@@ -482,7 +593,10 @@
    "execution_count": null,
    "id": "22220ae3-9fb4-471c-b5aa-f606deeca15e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -492,7 +606,11 @@
   {
    "cell_type": "markdown",
    "id": "bdee7afc-699b-4c1a-aeec-df0f99764ae0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Setting PATH variables for JDK and Maven and executing MAVEN build"
    ]
@@ -502,7 +620,10 @@
    "execution_count": null,
    "id": "4b40f634-1983-4267-a4c1-b072bf6d81ae",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -514,7 +635,11 @@
   {
    "cell_type": "markdown",
    "id": "9e1a779f-2c39-42ec-98be-0f5e9d715447",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Copying JARS files to GCS_STAGING_LOCATION"
    ]
@@ -524,7 +649,10 @@
    "execution_count": null,
    "id": "939cdcd5-0f3e-4f51-aa78-93d1976cb0f4",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -537,7 +665,11 @@
   {
    "cell_type": "markdown",
    "id": "0d9bb170-09c4-40d1-baaf-9e907f215889",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 8: Calculate Parallel Jobs for Oracle to Cloud Spanner\n",
     "This step uses MAX_PARALLELISM parameter to calculate number of parallel jobs to run"
@@ -548,7 +680,10 @@
    "execution_count": null,
    "id": "2c501db0-c1fb-4a05-88b8-a7e546e2b1d0",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -572,7 +707,11 @@
   {
    "cell_type": "markdown",
    "id": "78f6f83b-891a-4515-a1d6-f3406a25dc2a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 9: Execute Pipeline to Migrate tables from Oracle to Cloud Spanner"
    ]
@@ -582,7 +721,10 @@
    "execution_count": null,
    "id": "1f98914b-bd74-4d0e-9562-7019d504a25e",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -594,7 +736,10 @@
    "execution_count": null,
    "id": "863fa2d8-4ef7-4722-87c8-eec6c06f892b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -662,6 +807,7 @@
     "                jar_file_uris=JAR_FILE_URIS,\n",
     "                file_uris=FILE_URIS,\n",
     "                subnetwork_uri=SUBNETWORK_URI,\n",
+    "                runtime_config_version=\"1.1\", # issue 665\n",
     "                args=TEMPLATE_SPARK_ARGS\n",
     "            )\n",
     "            time.sleep(3)\n",
@@ -682,7 +828,10 @@
    "execution_count": null,
    "id": "44205b54-1ac7-42f3-85ad-5b20f531056b",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -694,7 +843,11 @@
   {
    "cell_type": "markdown",
    "id": "9ce7f828-dacc-404b-8927-dc3813e7216a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 10: Get status for tables migrated from Oracle to Cloud Spanner"
    ]
@@ -704,7 +857,10 @@
    "execution_count": null,
    "id": "b611510f-271c-447a-899d-42fbb983268d",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -735,7 +891,10 @@
    "execution_count": null,
    "id": "d1fcbc63-19db-42a8-a2ed-d9855da00c04",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -753,7 +912,10 @@
    "execution_count": null,
    "id": "5be3cf87-6d28-4b23-8466-87d3399f7a29",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -777,7 +939,10 @@
    "execution_count": null,
    "id": "1097575d-07c2-4659-a75f-d7e898e3f077",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -788,7 +953,11 @@
   {
    "cell_type": "markdown",
    "id": "0961f164-c7e4-4bb5-80f0-25fd1051147b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Step 11: Validate row counts of migrated tables from Oracle to Cloud Spanner"
    ]
@@ -798,7 +967,10 @@
    "execution_count": null,
    "id": "8a3a28fb-3a39-4a10-b92d-0685b351a1b3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -811,7 +983,10 @@
    "execution_count": null,
    "id": "25299344-c167-4764-a5d1-56c1b384d104",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -829,7 +1004,10 @@
    "execution_count": null,
    "id": "ab0e539d-5180-4f5b-915e-35f7ea45e0d3",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -852,7 +1030,10 @@
    "execution_count": null,
    "id": "4b1afe12-3eb9-4133-8377-66dc63ac649c",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -866,7 +1047,10 @@
    "execution_count": null,
    "id": "e7287b54-9abe-4134-9665-9a6d9a8bbb04",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": []


### PR DESCRIPTION
This PR adds the runtime_config_version property = "1.1" to the DataprocPySparkBatchOp, when submitting dataproc serverless jobs from the notebooks, to fix the error caused by the new default runtime, incompatible with the dependencies that we are using, which were compiled against Scala 2.12.

fix #665 