### PR TITLE
docs: fix JDBC To Spanner property name

### DIFF
--- a/java/src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md
+++ b/java/src/main/java/com/google/cloud/dataproc/templates/jdbc/README.md
@@ -275,7 +275,7 @@ bin/start.sh \
 --templateProperty jdbctospanner.output.table=<spanner table id> \
 --templateProperty jdbctospanner.output.saveMode=<Append|Overwrite|ErrorIfExists|Ignore> \
 --templateProperty jdbctospanner.output.primaryKey=<column[(,column)*] - primary key columns needed when creating the table> \
---templateProperty jdbctospanner.output.batchInsertSize=<optional integer>
+--templateProperty jdbctospanner.output.batch.size=<optional integer>
 ```
 
 **Note**: Following is example JDBC URL for MySQL database:
@@ -327,7 +327,7 @@ Example execution:
     --templateProperty jdbctospanner.output.table='spanner-table-name' \
     --templateProperty jdbctospanner.output.saveMode=Overwrite \
     --templateProperty jdbctospanner.output.primaryKey='primary-key' \
-    --templateProperty jdbctospanner.output.batchInsertSize=200
+    --templateProperty jdbctospanner.output.batch.size=200
 
 There are two optional properties as well with "JDBC to SPANNER" Template. Please find below the details :-
 


### PR DESCRIPTION
Updated jdbctospanner.output.batch.size property name in the docs