### PR TITLE
fix: Exclude GRPC jar file from Spanner notebooks

### DIFF
--- a/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
+++ b/notebooks/mysql2spanner/MySqlToSpanner_notebook.ipynb
@@ -340,14 +340,11 @@
     "JDBC_URL = \"jdbc:mysql://{}:{}/{}?user={}&password={}\".format(MYSQL_HOST,MYSQL_PORT,MYSQL_DATABASE,MYSQL_USERNAME,MYSQL_PASSWORD)\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
     "JAR_FILE = \"dataproc-templates-1.0-SNAPSHOT.jar\"\n",
-    "GRPC_JAR_PATH = \"./grpc_lb/io/grpc/grpc-grpclb/1.40.1\"\n",
-    "GRPC_JAR = \"grpc-grpclb-1.40.1.jar\"\n",
     "LOG4J_PROPERTIES_PATH = \"./src/test/resources\"\n",
     "LOG4J_PROPERTIES = \"log4j-spark-driver-template.properties\"\n",
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\"\n",
     "\n",
-    "# adding dataproc template JAR and grpc jar\n",
-    "JARS.append(GCS_STAGING_LOCATION + \"/\" + GRPC_JAR)\n",
+    "# Adding dataproc template JAR\n",
     "JARS.append(GCS_STAGING_LOCATION + \"/\" + JAR_FILE)"
    ]
   },
@@ -623,8 +620,7 @@
    "source": [
     "!wget https://downloads.mysql.com/archives/get/p/3/file/mysql-connector-java-8.0.29.tar.gz\n",
     "!tar -xf mysql-connector-java-8.0.29.tar.gz\n",
-    "!mvn clean spotless:apply install -DskipTests \n",
-    "!mvn dependency:get -Dartifact=io.grpc:grpc-grpclb:1.40.1 -Dmaven.repo.local=./grpc_lb "
+    "!mvn clean spotless:apply install -DskipTests "
    ]
   },
   {
@@ -652,7 +648,6 @@
    "outputs": [],
    "source": [
     "!gsutil cp target/$JAR_FILE $GCS_STAGING_LOCATION/$JAR_FILE\n",
-    "!gsutil cp $GRPC_JAR_PATH/$GRPC_JAR $GCS_STAGING_LOCATION/$GRPC_JAR\n",
     "!gsutil cp $LOG4J_PROPERTIES_PATH/$LOG4J_PROPERTIES $GCS_STAGING_LOCATION/$LOG4J_PROPERTIES\n",
     "!gsutil cp mysql-connector-java-8.0.29/mysql-connector-java-8.0.29.jar $GCS_STAGING_LOCATION/jars/mysql-connector-java-8.0.29.jar"
    ]

--- a/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
+++ b/notebooks/oracle2spanner/OracleToSpanner_notebook.ipynb
@@ -413,14 +413,11 @@
     "JDBC_SESSION_INIT_STATEMENT = \"BEGIN DBMS_APPLICATION_INFO.SET_MODULE('Dataproc Templates','OracleToSpanner Notebook'); END;\"\n",
     "MAIN_CLASS = \"com.google.cloud.dataproc.templates.main.DataProcTemplate\"\n",
     "JAR_FILE = \"dataproc-templates-1.0-SNAPSHOT.jar\"\n",
-    "GRPC_JAR_PATH = \"./grpc_lb/io/grpc/grpc-grpclb/1.40.1\"\n",
-    "GRPC_JAR = \"grpc-grpclb-1.40.1.jar\"\n",
     "LOG4J_PROPERTIES_PATH = \"./src/test/resources\"\n",
     "LOG4J_PROPERTIES = \"log4j-spark-driver-template.properties\"\n",
     "PIPELINE_ROOT = GCS_STAGING_LOCATION + \"/pipeline_root/dataproc_pyspark\"\n",
     "\n",
-    "# adding dataproc template JAR and grpc jar\n",
-    "JARS.append(GCS_STAGING_LOCATION + \"/\" + GRPC_JAR)\n",
+    "# adding dataproc template JAR\n",
     "JARS.append(GCS_STAGING_LOCATION + \"/\" + JAR_FILE)"
    ]
   },
@@ -628,8 +625,7 @@
    "outputs": [],
    "source": [
     "!wget --no-verbose https://repo1.maven.org/maven2/com/oracle/database/jdbc/ojdbc8/21.7.0.0/ojdbc8-21.7.0.0.jar\n",
-    "!mvn -q clean spotless:apply install -DskipTests \n",
-    "!mvn -q dependency:get -Dartifact=io.grpc:grpc-grpclb:1.40.1 -Dmaven.repo.local=./grpc_lb "
+    "!mvn -q clean spotless:apply install -DskipTests "
    ]
   },
   {
@@ -657,7 +653,6 @@
    "outputs": [],
    "source": [
     "!gsutil cp target/$JAR_FILE $GCS_STAGING_LOCATION/$JAR_FILE\n",
-    "!gsutil cp $GRPC_JAR_PATH/$GRPC_JAR $GCS_STAGING_LOCATION/$GRPC_JAR\n",
     "!gsutil cp $LOG4J_PROPERTIES_PATH/$LOG4J_PROPERTIES $GCS_STAGING_LOCATION/$LOG4J_PROPERTIES\n",
     "!gsutil cp ojdbc8-21.7.0.0.jar $GCS_STAGING_LOCATION/jars/ojdbc8-21.7.0.0.jar"
    ]


### PR DESCRIPTION
Removed references to GRPC jar file from two notebooks:

- OracleToSpanner_notebook.ipynb
- MySqlToSpanner_notebook.ipynb

I've tested the changes using `OracleToSpanner_notebook.ipynb` on branch `feature/issue-650-notebook-jdbc-refactor` and then ported to `main`. I was unable to test on `main` because the code is not SQLAlchemy 2.0 compatible. This will be resolved when merging `feature/issue-650-notebook-jdbc-refactor`.